### PR TITLE
Solve #3 (docker labels) and #7 (secrets), and provide a sane default config for single-command-deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,7 @@
 /.git
 /.github
 /.res
+!/.res/compose/diun.yml
 /bin
 /dist
 /doc

--- a/.res/compose/diun.yml
+++ b/.res/compose/diun.yml
@@ -1,0 +1,19 @@
+# Documentation for this file is available at https://github.com/crazy-max/diun/blob/master/doc/configuration.md
+
+watch:
+  workers: 10
+  schedule: "0 0 * * * *"
+  docker: true
+  unlabeled-containers: true
+  stopped-containers: true
+
+notif:
+  mail:
+    enable: true
+    host: "" # Enable direct SMTP
+    from: diun@crazy-max.github.io
+    to: '${EMAIL}'
+
+db: { path: diun.db }
+regopts: {}
+image: []

--- a/.res/compose/docker-compose.yml
+++ b/.res/compose/docker-compose.yml
@@ -3,12 +3,15 @@ version: "3.2"
 services:
   diun:
     image: crazymax/diun:latest
+    restart: always
     container_name: diun
     volumes:
       - "./data:/data"
       - "./diun.yml:/diun.yml:ro"
+      - "/var/run/docker.sock:/var/run/docker.sock"
     environment:
       - "TZ=Europe/Paris"
       - "LOG_LEVEL=info"
       - "LOG_JSON=false"
-    restart: always
+      - "EMAIL=mail@example.org"
+      - "HELO=${HOSTNAME}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,8 +47,6 @@ RUN apk --update --no-cache add \
     libressl \
     shadow \
     tzdata \
-  && addgroup -g 1000 diun \
-  && adduser -u 1000 -G diun -s /sbin/nologin -D diun \
   && rm -rf /tmp/* /var/cache/apk/*
 
 COPY --from=builder /app/diun /usr/local/bin/diun
@@ -57,7 +55,8 @@ RUN diun --version
 
 ENV DIUN_DB="/data/diun.db"
 
-USER diun
+# Required for access to /var/run/docker.sock
+USER root
 
 VOLUME [ "/data" ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,7 @@ ENV DIUN_DB="/data/diun.db"
 # Required for access to /var/run/docker.sock
 USER root
 
+COPY .res/compose/diun.yml /diun.yml
 VOLUME [ "/data" ]
 
 ENTRYPOINT [ "diun" ]

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 
 ## Features
 
+* :new: Watch images used by currently running containers
 * Allow to watch a full Docker repository and report new tags
 * Include and exclude filters with regular expression for tags
 * Internal cron implementation through go routines
@@ -32,11 +33,12 @@
 ## Documentation
 
 * Install
-  * [With Docker](doc/install/docker.md)
+  * [With Docker (recommended)](doc/install/docker.md)
   * [From binary](doc/install/binary.md)
   * [Linux service](doc/install/linux-service.md)
 * [Usage](doc/usage.md)
 * [Configuration](doc/configuration.md)
+* [Container Labels](doc/labels.md)
 * [Notifications](doc/notifications.md)
 * [TODO](doc/todo.md)
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,20 @@
 * [Notifications](doc/notifications.md)
 * [TODO](doc/todo.md)
 
+## Quick Start
+
+This example is the quickest way to try out Diun on a hosted server - just make sure to put in your own email address.
+It sends emails through [direct SMTP](doc/configuration.md#notif), and watches all docker containers unless they have the [`diun.enable=false` label](doc/labels.md) set.
+
+```bash
+docker run --restart=always --name=diun \
+  -e EMAIL=mail@example.org \
+  -e HELO="$HOSTNAME" \
+  -v "/var/lib/diun:/data" \
+  -v "/var/run/docker.sock:/var/run/docker.sock" \
+  crazymax/diun:latest
+```
+
 ## How can I help ?
 
 All kinds of contributions are welcome :raised_hands:!<br />

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -73,6 +73,8 @@ image:
     arch: arm64v8
 ```
 
+Environment variables written like `${VARIABLE}` are directly substituted before the file is parsed, and can be used e.g. for secrets.
+
 ## db
 
 * `db`

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -92,8 +92,8 @@ image:
 * `notif`
   * `mail`
     * `enable`: Enable email reports (default: `false`).
-    * `host`: SMTP server host (default: `localhost`). **required**
-    * `port`: SMTP server port (default: `25`). **required**
+    * `host`: SMTP server host (default: direct SMTP).
+    * `port`: SMTP server port (default: `25`).
     * `ssl`: SSL defines whether an SSL connection is used. Should be false in most cases since the auth mechanism should use STARTTLS (default: `false`).
     * `insecure_skip_verify`: Controls whether a client verifies the server's certificate chain and host name (default: `false`).
     * `username`: SMTP username.
@@ -106,6 +106,16 @@ image:
     * `method`: HTTP method (default: `GET`). **required**
     * `headers`: Map of additional headers to be sent.
     * `timeout`: Timeout specifies a time limit for the request to be made. (default: `10`).
+
+### Direct SMTP
+If the `host` field is empty or missing, direct SMTP is being used. That means, the email is directly sent to the receiver's email server.
+This should only be used for testing, and comes with some challenges, so in most cases you probably want to use your own SMTP server for better reliability.
+
+For most email providers, you need a valid `HELO` hostname, which can be set using the `HELO` environment variable (or `HOSTNAME`, if `HELO` is not set).  
+This hostname has to point to the static IP address of the server Diun is running on, and the IP address should have its PTR record set to this hostname.
+This makes direct SMTP unsuitable for development machines or in a homelab environment.
+
+More information on this topic is available at https://www.linuxmagic.com/best_practices/valid_helo_domain.html.
 
 ## regopts
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -9,6 +9,9 @@ db:
 watch:
   workers: 10
   schedule: "0 0 * * * *"
+  docker: true
+  unlabeled-containers: true
+  stopped-containers: true
 
 notif:
   mail:
@@ -80,6 +83,9 @@ image:
 * `watch`
   * `workers`: Maximum number of workers that will execute tasks concurrently. _Optional_. (default: `10`).
   * `schedule`: [CRON expression](https://godoc.org/github.com/crazy-max/cron#hdr-CRON_Expression_Format) to schedule Diun watcher. _Optional_. (default: `0 0 * * * *`).
+  * `docker`: If `true`, connect to the docker daemon and watch for container changes. The socket path can be specified using the `DOCKER_HOST` environment variable. _Optional_. (default: `false`)
+  * `unlabeled-containers`: Should all containers be watched by default? If `false`, [labels](labels.md) have to be specified for a container to be watched. _Optional_. (default: `false`)
+  * `stopped-containers`: Should stopped containers be watched? _Optional_. (default: `false`)
 
 ## notif
 

--- a/doc/labels.md
+++ b/doc/labels.md
@@ -1,0 +1,12 @@
+# Labels
+
+Docker containers can be configured to be watched using [labels](https://docs.docker.com/config/labels-custom-metadata/):
+
+| Label | Description |
+| ----- | ----------- |
+| `diun`<br>`diun.enable=true` | Enable Diun |
+| `diun=1.2.*` | Shorthand for `diun.enable=true` and `diun.include_tags=1.2.*` |
+| `diun.enable=false` | Disable Diun, even if `unlabeled-containers` is `true` |
+| `diun.os=...`<br>`diun.arch=...`<br>`diun.watch_repo=true|false`<br>`diun.max_tags=0`<br>`diun.regopts_id=...` | Set the corresponding [configuration option](configuration.md#image) |
+| `diun.include_tags=...`<br>`diun.include_tags.1=...`<br>`diun.include_tags.xyz=...` | Add an expression to the `include_tags` option, and set `watch_repo` to `true` if missing |
+| `diun.exclude_tags=...`<br>`diun.exclude_tags.1=...`<br>`diun.exclude_tags.xyz=...` | Add an expression to the `exclude_tags` option |

--- a/doc/todo.md
+++ b/doc/todo.md
@@ -1,5 +1,5 @@
 # TODO
 
-* [ ] Watch images inside Dockerfile and Compose files
-* [ ] Watch images from Docker daemon
+* [x] Watch images inside Dockerfile and Compose files
+* [x] Watch images from Docker daemon
 * [ ] Watch starred repo on DockerHub and Quay

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,15 @@
 module github.com/crazy-max/diun
 
 require (
+	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
+	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4 // indirect
 	github.com/containerd/continuity v0.0.0-20190815185530-f2a389ac0a02 // indirect
 	github.com/containers/image v3.0.2+incompatible
 	github.com/containers/storage v1.13.2 // indirect
 	github.com/docker/distribution v2.7.1+incompatible // indirect
+	github.com/docker/docker v0.0.0-20171019062838-86f080cff091
 	github.com/docker/docker-credential-helpers v0.6.3 // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-metrics v0.0.0-20181218153428-b84716841b82 // indirect
@@ -17,8 +20,6 @@ require (
 	github.com/hako/durafmt v0.0.0-20190612201238-650ed9f29a84
 	github.com/imdario/mergo v0.3.7
 	github.com/matcornic/hermes/v2 v2.0.2
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0-rc1
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/panjf2000/ants v1.0.0
@@ -28,6 +29,8 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.3.0
 	go.etcd.io/bbolt v1.3.3
+	golang.org/x/time v0.0.0-20190921001708-c4c64cad1fd0 // indirect
+	google.golang.org/grpc v1.24.0 // indirect
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
 	gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df // indirect
@@ -35,3 +38,5 @@ require (
 )
 
 replace github.com/docker/docker => github.com/docker/engine v0.0.0-20190423201726-d2cfbce3f3b0
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,6 @@
+cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 h1:w+iIsaOQNcT7OZ575w+acHgRric5iCyQh+xv+KJ4HB8=
+github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/DataDog/zstd v1.4.0/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
@@ -8,6 +11,8 @@ github.com/Masterminds/sprig v2.16.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuN
 github.com/Microsoft/go-winio v0.4.12 h1:xAfWHN1IrQ0NJ9TBC0KBZoqLjzDTr1ML+4MywiUOryc=
 github.com/Microsoft/go-winio v0.4.12/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/hcsshim v0.8.6/go.mod h1:Op3hHsoHPAvb6lceZHDtd9OkTew38wNoXnJs8iY7rUg=
+github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
+github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -20,6 +25,7 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/containerd/continuity v0.0.0-20190815185530-f2a389ac0a02 h1:tN9D97v5A5QuKdcKHKt+UMKrkQ5YXUnD8iM7IAAjEfI=
 github.com/containerd/continuity v0.0.0-20190815185530-f2a389ac0a02/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/containers/image v3.0.2+incompatible h1:B1lqAE8MUPCrsBLE86J0gnXleeRq8zJnQryhiiGQNyE=
@@ -52,7 +58,11 @@ github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/gogo/protobuf v1.1.1 h1:72R+M5VuhED/KujmZVcIquuo8mBgX4oVda//DQb3PXo=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
+github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
@@ -164,6 +174,7 @@ golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20181029175232-7e6ffbd03851/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/net v0.0.0-20181029044818-c44066c5c816/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a h1:oWX7TPOiFAMXLq8o0ikBYfCJVlRHBcsciT5bXOrH628=
@@ -171,6 +182,7 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190628185345-da137c7871d7 h1:rTIdg5QFRR7XCaK4LCjBiPbx8j4DQRpdYMnGn/bJUEU=
 golang.org/x/net v0.0.0-20190628185345-da137c7871d7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -183,9 +195,19 @@ golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb h1:fgwFCsaw9buMuxNd6+DQfAuSF
 golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3 h1:4y9KwBHBgBNwDbtu44R5o1fdOCQUEXhbk/P4A9WmJq0=
 golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/time v0.0.0-20190921001708-c4c64cad1fd0 h1:xQwXv67TxFo9nC1GJFyab5eq/5B590r6RlnL/G8Sz7w=
+golang.org/x/time v0.0.0-20190921001708-c4c64cad1fd0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180810170437-e96c4e24768d/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190425163242-31fd60d6bfdc/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
+google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8 h1:Nw54tB0rB7hY/N0NQvRW8DG4Yk3Q6T9cu9RcFQDu1tc=
+google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
+google.golang.org/grpc v1.24.0 h1:vb/1TCsVn3DcJlQ0Gs1yB1pKI6Do2/QNwxdKqmc/b0s=
+google.golang.org/grpc v1.24.0/go.mod h1:XDChyiUovWa60DnaeDeZmSW86xtLtjtZbwvSiRnRtcA=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc h1:2gGKlE2+asNV9m7xrywl36YYNnBG5ZQ0r/BOOxqPpmk=
@@ -200,3 +222,4 @@ gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gotest.tools v0.0.0-20190624233834-05ebafbffc79 h1:C+K4iPg1rIvmCf4JjelkbWv2jeWevEwp05Lz8XfTYgE=
 gotest.tools v0.0.0-20190624233834-05ebafbffc79/go.mod h1:R//lfYlUuTOTfblYI3lGoAAAebUdzjvbmQsuB7Ykd90=
+honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/internal/app/diun.go
+++ b/internal/app/diun.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/crazy-max/diun/internal/config"
 	"github.com/crazy-max/diun/internal/db"
+	"github.com/crazy-max/diun/internal/docker"
 	"github.com/crazy-max/diun/internal/notif"
 	"github.com/hako/durafmt"
 	"github.com/panjf2000/ants"
@@ -30,6 +31,12 @@ type Diun struct {
 func New(cfg *config.Config, location *time.Location) (*Diun, error) {
 	// DB client
 	dbcli, err := db.New(cfg.Db)
+	if err != nil {
+		return nil, err
+	}
+
+	// Docker Watcher
+	err = docker.New(cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -112,6 +119,7 @@ func (di *Diun) Close() {
 	if di.cron != nil {
 		di.cron.Stop()
 	}
+	docker.Stop()
 	if err := di.db.Close(); err != nil {
 		log.Warn().Err(err).Msg("Cannot close database")
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -151,7 +151,7 @@ func (cfg *Config) validateRegOpts(id string, regopts model.RegOpts) (model.RegO
 	return model.RegOpts{}, nil
 }
 
-// PutImage validates and adds/updates a RegOpts object to the configuration
+// PutRegOpts validates and adds/updates a RegOpts object to the configuration
 func (cfg *Config) PutRegOpts(id string, regopts model.RegOpts) error {
 	regopts, err := cfg.validateRegOpts(id, regopts)
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -82,7 +82,7 @@ func Load(flags model.Flags, version string) (*Config, error) {
 		if len(parts) > 1 {
 			value = parts[1]
 		}
-		bytes.ReplaceAll(cfgBytes, []byte("${" + parts[0] + "}"), []byte(value))
+		cfgBytes = bytes.ReplaceAll(cfgBytes, []byte("${" + parts[0] + "}"), []byte(value))
 	}
 
 	if err := yaml.UnmarshalStrict(cfgBytes, &cfg); err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -120,6 +120,9 @@ func (cfg *Config) validate() error {
 	}
 
 	if cfg.Notif.Mail.Enable {
+		if cfg.Notif.Mail.Host == "" {
+			log.Warn().Msg("You're using direct SMTP! This is okay for testing Diun on a real server, but for production or in a homelab, you will need to use your own SMTP server. More information: https://github.com/crazy-max/diun/blob/master/doc/configuration.md#notif")
+		}
 		if _, err := mail.ParseAddress(cfg.Notif.Mail.From); err != nil {
 			return fmt.Errorf("cannot parse sender mail address, %v", err)
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -103,20 +103,20 @@ func (cfg *Config) validate() error {
 	}
 	cfg.Db.Path = path.Clean(cfg.Db.Path)
 
+	var err error
+
 	for id, regopts := range cfg.RegOpts {
-		if regopts, err := cfg.validateRegOpts(id, regopts); err != nil {
+		if regopts, err = cfg.validateRegOpts(id, regopts); err != nil {
 			return err
-		} else {
-			cfg.RegOpts[id] = regopts
 		}
+		cfg.RegOpts[id] = regopts
 	}
 
 	for key, img := range cfg.Image {
-		if img, err := cfg.validateImage(key, img); err != nil {
+		if img, err = cfg.validateImage(key, img); err != nil {
 			return err
-		} else {
-			cfg.Image[key] = img
 		}
+		cfg.Image[key] = img
 	}
 
 	if cfg.Notif.Mail.Enable {
@@ -151,6 +151,7 @@ func (cfg *Config) validateRegOpts(id string, regopts model.RegOpts) (model.RegO
 	return model.RegOpts{}, nil
 }
 
+// PutImage validates and adds/updates a RegOpts object to the configuration
 func (cfg *Config) PutRegOpts(id string, regopts model.RegOpts) error {
 	regopts, err := cfg.validateRegOpts(id, regopts)
 	if err != nil {
@@ -159,6 +160,7 @@ func (cfg *Config) PutRegOpts(id string, regopts model.RegOpts) error {
 	cfg.RegOpts[id] = regopts
 	return nil
 }
+// RemoveRegOpts removes a RegOpts object from the configuration by its ID
 func (cfg *Config) RemoveRegOpts(id string) error {
 	if _, ok := cfg.RegOpts[id]; !ok {
 		return errors.New("no entry with this id")
@@ -204,6 +206,7 @@ func (cfg *Config) validateImage(key int, img model.Image) (model.Image, error) 
 	return img, nil
 }
 
+// AddImage validates and adds a new image to the configuration
 func (cfg *Config) AddImage(img model.Image) error {
 	img, err := cfg.validateImage(len(cfg.Image), img)
 	if err != nil {
@@ -212,6 +215,7 @@ func (cfg *Config) AddImage(img model.Image) error {
 	cfg.Image = append(cfg.Image, img)
 	return nil
 }
+// SetImage validates and updates an image in the configuration at a specific index
 func (cfg *Config) SetImage(key int, img model.Image) error {
 	img, err := cfg.validateImage(key, img)
 	if err != nil {
@@ -220,6 +224,7 @@ func (cfg *Config) SetImage(key int, img model.Image) error {
 	cfg.Image[key] = img
 	return nil
 }
+// RemoveImage removes an image from the configuration at a specific index
 func (cfg *Config) RemoveImage(key int) error {
 	if key < 0 || key >= len(cfg.Image) {
 		return errors.New("index out of range")

--- a/internal/docker/update.go
+++ b/internal/docker/update.go
@@ -142,7 +142,6 @@ func container2image(container types.Container) model.Image {
 func name(n []string, id string) string {
 	if len(n) > 0 {
 		return n[0]
-	} else {
-		return id[:11]
 	}
+	return id[:11]
 }

--- a/internal/docker/update.go
+++ b/internal/docker/update.go
@@ -1,0 +1,148 @@
+package docker
+
+import (
+	"context"
+	"github.com/crazy-max/diun/internal/config"
+	"github.com/crazy-max/diun/internal/model"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/client"
+	"github.com/rs/zerolog/log"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+var queued = false
+var working = false
+var workingMutex = sync.Mutex{}
+
+func update(cfg *config.Config, cli *client.Client) error {
+	if working {
+		queued = true
+	}
+	working = true
+	workingMutex.Lock()
+
+	// Filter containers so we only get relevant ones
+	args := filters.NewArgs()
+	if !cfg.Watch.StoppedContainers {
+		args.Add("status", "running")
+		args.Add("status", "restarting")
+		args.Add("status", "paused")
+	}
+	if !cfg.Watch.UnlabeledContainers {
+		args.Add("label", "diun")
+		args.Add("label", "diun.enable=true")
+	}
+
+	time.Sleep(2 * time.Second)
+	containers, err := cli.ContainerList(context.Background(), types.ContainerListOptions{Filters: args})
+	if err != nil {
+		return err
+	}
+
+	// watched contains true for all existing containers that are being watched, for easier lookup when removing old images
+	watched := map[string]bool{}
+
+	countAdd := 0
+	countUpd := 0
+	countDel := 0
+	countErr := 0
+	log.Debug().Msgf("Old Config: %+v", cfg.Image)
+
+	for _, container := range containers {
+		if container.Labels["diun.enable"] == "false" {
+			continue
+		}
+
+		watched[container.ID] = true
+
+		found := false
+		for i := range cfg.Image {
+			if cfg.Image[i].SourceContainer != "" && cfg.Image[i].SourceContainer == container.ID {
+				// Image exists, update the entry
+				found = true
+				if err := cfg.SetImage(i, container2image(container)); err != nil {
+					countErr++
+					log.Error().Str("container", name(container.Names, container.ID)).Err(err).Msg("Invalid configuration")
+				} else {
+					countUpd++
+				}
+				break
+			}
+		}
+		if !found {
+			// Image doesn't exist, create the entry
+			if err := cfg.AddImage(container2image(container)); err != nil {
+				countErr++
+				log.Error().Str("container", name(container.Names, container.ID)).Err(err).Msg("Invalid configuration")
+			} else {
+				countAdd++
+			}
+		}
+	}
+
+	for i := 0; i < len(cfg.Image); i++ {
+		if cfg.Image[i].SourceContainer != "" && !watched[cfg.Image[i].SourceContainer] {
+			// Container doesn't exist, remove the entry
+			cfg.RemoveImage(i)
+			countDel++
+			i--
+		}
+	}
+
+	if countErr > 0 || countAdd > 0 || countDel > 0 || countUpd > 0 {
+		log.Info().Msgf("Containers updated: %d added, %d unmodified/updated, %d removed, %d failed", countAdd, countUpd, countDel, countErr)
+	}
+
+	working = false
+	if queued {
+		return update(cfg, cli)
+	}
+	workingMutex.Unlock()
+	return nil
+}
+
+func container2image(container types.Container) model.Image {
+	img := model.Image{
+		SourceContainer: container.ID,
+		Name:            container.Image,
+		Os:              container.Labels["diun.os"],
+		Arch:            container.Labels["diun.arch"],
+		RegOptsID:       container.Labels["diun.regopts_id"],
+		WatchRepo:       container.Labels["diun.watch_repo"] == "true",
+		MaxTags:         0,
+		IncludeTags:     []string{},
+		ExcludeTags:     []string{},
+	}
+	if maxTags, ok := container.Labels["diun.max_tags"]; ok {
+		var err error
+		img.MaxTags, err = strconv.Atoi(maxTags)
+		if err != nil {
+			log.Warn().Str("container", name(container.Names, container.ID)).Err(err).Msg("diun.max_tags is not an integer, using default value 0")
+		}
+	}
+	for l, v := range container.Labels {
+		if l == "diun.include_tags" || strings.HasPrefix(l, "diun.include_tags.") || (l == "diun" && v != "true" && v != "false" && v != "") {
+			if _, ok := container.Labels["diun.watch_repo"]; !ok {
+				img.WatchRepo = true
+			}
+			img.IncludeTags = append(img.IncludeTags, v)
+		}
+		if l == "diun.exclude_tags" || strings.HasPrefix(l, "diun.exclude_tags.") {
+			img.ExcludeTags = append(img.ExcludeTags, v)
+		}
+	}
+
+	return img
+}
+
+func name(n []string, id string) string {
+	if len(n) > 0 {
+		return n[0]
+	} else {
+		return id[:11]
+	}
+}

--- a/internal/docker/watch.go
+++ b/internal/docker/watch.go
@@ -1,0 +1,102 @@
+package docker
+
+import (
+	"context"
+	"fmt"
+	"github.com/crazy-max/diun/internal/config"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/client"
+	"github.com/rs/zerolog/log"
+	"time"
+)
+
+// New creates and starts a new docker watcher
+func New(cfg *config.Config) error {
+	if !cfg.Watch.Docker {
+		// The feature is disabled
+		stopped = true
+		return nil
+	}
+
+	// Try to connect to the docker daemon
+	cli, err := client.NewClientWithOpts(client.FromEnv)
+	if err != nil {
+		stopped = true
+		return fmt.Errorf("couldn't connect to docker daemon: %v", err)
+	}
+
+	log.Info().Msg("Connection to docker container established")
+
+	update(cfg, cli)
+	go watch(cfg, cli)
+	return nil
+}
+
+var shouldStop = make(chan bool)
+var hasStopped = make(chan bool)
+var stopped = false
+
+func Stop() {
+	// Stop the update loop, notify watch() that it should stop, and wait until it has stopped
+	if stopped {
+		return
+	}
+	stopped = true
+	select {
+	case shouldStop <- true:
+		<-hasStopped
+	case <-hasStopped:
+	}
+}
+
+func watch(cfg *config.Config, cli *client.Client) {
+	// Filter events so we only get relevant ones
+	args := filters.NewArgs()
+	args.Add("type", "container")
+	if cfg.Watch.StoppedContainers {
+		args.Add("event", "create")
+		args.Add("event", "destroy")
+	} else {
+		args.Add("event", "start")
+		args.Add("event", "stop")
+	}
+	if !cfg.Watch.UnlabeledContainers {
+		args.Add("label", "diun")
+		args.Add("label", "diun.enable")
+	}
+
+	ctx, ctxCancel := context.WithCancel(context.Background())
+	for !stopped {
+		// Wait for the relevant events from the docker daemon
+		events, dockerErrors := cli.Events(ctx, types.EventsOptions{Filters: args})
+		log.Debug().Msg("Now listening to docker events")
+		for !stopped {
+			select {
+
+			case <-events:
+				// An update will be done during the next iteration of the inner for loop
+				err := update(cfg, cli)
+				for ; err != nil; err = update(cfg, cli) {
+					// The update function threw an error
+					log.Error().Err(err).Msg("Error when updating watched docker containers, waiting 30 seconds before trying again")
+					time.Sleep(30 * time.Second)
+				}
+
+			case err := <-dockerErrors:
+				// The docker events channel threw an error
+				log.Error().Err(err).Msg("Error in docker event channel, waiting 30 seconds before trying again")
+				time.Sleep(30 * time.Second)
+				break // Recreate the events channel in the outer for loop
+
+			case <-shouldStop:
+				// `stopped` is now true, so we'll quit both for loops
+				break
+
+			}
+		}
+	}
+	// Cancel the docker event context and notify the Close() function that everything has been stopped
+	ctxCancel()
+	hasStopped <- true
+}

--- a/internal/docker/watch.go
+++ b/internal/docker/watch.go
@@ -37,8 +37,8 @@ var shouldStop = make(chan bool)
 var hasStopped = make(chan bool)
 var stopped = false
 
+// Stop terminates the update loop, notifies watch() that it should stop, and wait until it has stopped
 func Stop() {
-	// Stop the update loop, notify watch() that it should stop, and wait until it has stopped
 	if stopped {
 		return
 	}

--- a/internal/model/image.go
+++ b/internal/model/image.go
@@ -10,13 +10,14 @@ type RegOpts struct {
 
 // Image holds image configuration
 type Image struct {
-	Name        string   `yaml:"name,omitempty" json:",omitempty"`
-	Os          string   `yaml:"os,omitempty" json:",omitempty"`
-	Arch        string   `yaml:"arch,omitempty" json:",omitempty"`
-	RegOptsID   string   `yaml:"regopts_id,omitempty" json:",omitempty"`
-	WatchRepo   bool     `yaml:"watch_repo,omitempty" json:",omitempty"`
-	MaxTags     int      `yaml:"max_tags,omitempty" json:",omitempty"`
-	IncludeTags []string `yaml:"include_tags,omitempty" json:",omitempty"`
-	ExcludeTags []string `yaml:"exclude_tags,omitempty" json:",omitempty"`
-	RegOpts     RegOpts  `yaml:"-" json:"-"`
+	Name            string   `yaml:"name,omitempty" json:",omitempty"`
+	Os              string   `yaml:"os,omitempty" json:",omitempty"`
+	Arch            string   `yaml:"arch,omitempty" json:",omitempty"`
+	RegOptsID       string   `yaml:"regopts_id,omitempty" json:",omitempty"`
+	WatchRepo       bool     `yaml:"watch_repo,omitempty" json:",omitempty"`
+	MaxTags         int      `yaml:"max_tags,omitempty" json:",omitempty"`
+	IncludeTags     []string `yaml:"include_tags,omitempty" json:",omitempty"`
+	ExcludeTags     []string `yaml:"exclude_tags,omitempty" json:",omitempty"`
+	RegOpts         RegOpts  `yaml:"-" json:"-"`
+	SourceContainer string   `yaml:"-" json:"-"`
 }

--- a/internal/model/watch.go
+++ b/internal/model/watch.go
@@ -2,6 +2,9 @@ package model
 
 // Watch holds data necessary for watch configuration
 type Watch struct {
-	Workers  int    `yaml:"workers,omitempty"`
-	Schedule string `yaml:"schedule,omitempty"`
+	Workers             int    `yaml:"workers,omitempty"`
+	Schedule            string `yaml:"schedule,omitempty"`
+	Docker              bool   `yaml:"docker,omitempty"`
+	UnlabeledContainers bool   `yaml:"unlabeled-containers,omitempty"`
+	StoppedContainers   bool   `yaml:"stopped-containers,omitempty"`
 }


### PR DESCRIPTION
Alright, this got a bit more complicated than I thought, but here is my implementation of the Docker label watcher (#3) :smiley:

I fixed #7 along the way to provide a really simple way to get everything up and running, so on a normal server, Diun can be set up now with a single command.

Also, this now includes a way to send emails when no `host` is set through direct SMTP - it has a few quirks due to the nature of email, but it should be documented quite well in configuration.md, and just makes quick testing a lot easier.