### PR TITLE
Add TEST_NOTIF variable for docker installation

### DIFF
--- a/doc/install/binary.md
+++ b/doc/install/binary.md
@@ -28,7 +28,7 @@ Flags:
   --log-level="info"    Set log level ($LOG_LEVEL).
   --log-json            Enable JSON logging output ($LOG_JSON).
   --log-caller          Add file:line of the caller to log output ($LOG_CALLER).
-  --test-notif          Test notification settings.
+  --test-notif          Test notification settings ($TEST_NOTIF).
 ```
 
 ## Server configuration

--- a/doc/install/docker.md
+++ b/doc/install/docker.md
@@ -24,6 +24,7 @@ Image: crazymax/diun:latest
 * `LOG_LEVEL` : Log level output (default `info`)
 * `LOG_JSON`: Enable JSON logging output (default `false`)
 * `LOG_CALLER`: Enable to add file:line of the caller (default `false`)
+* `TEST_NOTIF`: Enable to test notification settings on startup (default `false`)
 
 ## Volumes
 

--- a/internal/model/cli.go
+++ b/internal/model/cli.go
@@ -10,5 +10,5 @@ type Cli struct {
 	LogLevel  string `kong:"name='log-level',env='LOG_LEVEL',default='info',help='Set log level.'"`
 	LogJSON   bool   `kong:"name='log-json',env='LOG_JSON',default='false',help='Enable JSON logging output.'"`
 	LogCaller bool   `kong:"name='log-caller',env='LOG_CALLER',default='false',help='Add file:line of the caller to log output.'"`
-	TestNotif bool   `kong:"name='test-notif',default='false',help='Test notification settings.'"`
+	TestNotif bool   `kong:"name='test-notif',env='TEST_NOTIF',default='false',help='Test notification settings.'"`
 }


### PR DESCRIPTION
In order to use the feature introduced in #73 with the docker installation one has to override the [CMD](https://github.com/crazy-max/diun/blob/master/Dockerfile#L63) command from docker-compose applying the flag.

A documented environment variable mapping the flag might be more docker-like. Let me know what you think. 