### PR TITLE
allow to configure scheme for MQTT broker

### DIFF
--- a/docs/notif/mqtt.md
+++ b/docs/notif/mqtt.md
@@ -8,6 +8,7 @@ You can send notifications to any MQTT compatible server with the following sett
     ```yaml
     notif:
       mqtt:
+        scheme: mqtt
         host: localhost
         port: 1883
         username: guest
@@ -19,6 +20,7 @@ You can send notifications to any MQTT compatible server with the following sett
 
 | Name               | Default       | Description   |
 |--------------------|---------------|---------------|
+| `scheme`[^1]       | `mqtt`        | MQTT server scheme (`mqtt`, `mqtts`, `ws` or `wss`) |
 | `host`[^1]         | `localhost`   | MQTT server host |
 | `port`[^1]         | `1883`        | MQTT server port |
 | `username`         |               | MQTT username |
@@ -30,6 +32,7 @@ You can send notifications to any MQTT compatible server with the following sett
 | `qos`              | `0`           | Ensured message delivery at specified Quality of Service (QoS) |
 
 !!! abstract "Environment variables"
+    * `DIUN_NOTIF_MQTT_SCHEME`
     * `DIUN_NOTIF_MQTT_HOST`
     * `DIUN_NOTIF_MQTT_PORT`
     * `DIUN_NOTIF_MQTT_USERNAME`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -123,6 +123,7 @@ func TestLoadFile(t *testing.T) {
 						MsgType:       model.NotifMatrixMsgTypeNotice,
 					},
 					Mqtt: &model.NotifMqtt{
+						Scheme:   "mqtt",
 						Host:     "localhost",
 						Port:     1883,
 						Username: "guest",

--- a/internal/config/fixtures/config.test.yml
+++ b/internal/config/fixtures/config.test.yml
@@ -44,6 +44,7 @@ notif:
     password: bar
     roomID: "!abcdefGHIjklmno:matrix.org"
   mqtt:
+    scheme: "mqtt"
     host: "localhost"
     port: 1883
     username: "guest"

--- a/internal/config/fixtures/config.validate.yml
+++ b/internal/config/fixtures/config.validate.yml
@@ -44,6 +44,7 @@ notif:
     password: bar
     roomID: "!abcdefGHIjklmno:matrix.org"
   mqtt:
+    scheme: "mqtt"
     host: "localhost"
     port: 1883
     username: "guest"

--- a/internal/model/notif_mqtt.go
+++ b/internal/model/notif_mqtt.go
@@ -1,6 +1,7 @@
 package model
 
 type NotifMqtt struct {
+	Scheme       string `yaml:"scheme,omitempty" json:"scheme,omitempty" validate:"required,oneof=mqtt mqtts ws wss"`
 	Host         string `yaml:"host,omitempty" json:"host,omitempty" validate:"required"`
 	Port         int    `yaml:"port,omitempty" json:"port,omitempty" validate:"required,min=1"`
 	Username     string `yaml:"username,omitempty" json:"username,omitempty" validate:"omitempty"`
@@ -21,6 +22,7 @@ func (s *NotifMqtt) GetDefaults() *NotifMqtt {
 
 // SetDefaults sets the default values
 func (s *NotifMqtt) SetDefaults() {
+	s.Scheme = "mqtt"
 	s.Host = "localhost"
 	s.Port = 1883
 	s.QoS = 0

--- a/internal/notif/mqtt/client.go
+++ b/internal/notif/mqtt/client.go
@@ -49,7 +49,7 @@ func (c *Client) Send(entry model.NotifEntry) error {
 		return err
 	}
 
-	broker := fmt.Sprintf("tcp://%s:%d", c.cfg.Host, c.cfg.Port)
+	broker := fmt.Sprintf("%s://%s:%d", c.cfg.Scheme, c.cfg.Host, c.cfg.Port)
 	opts := MQTT.NewClientOptions().AddBroker(broker).SetClientID(c.cfg.Client)
 	opts.Username = username
 	opts.Password = password


### PR DESCRIPTION
## Use case
With MQTT server behind a reverse proxy, I want to enable TLS connection between diun and MQTT

## Manual tests
I tested the four kind of connection manually and it works as expected

## Note about naming
The [paho documentation](https://pkg.go.dev/github.com/eclipse/paho.mqtt.golang#ClientOptions.AddBroker) only mention `tcp`/`ssl`/`ws`
But [the library support](https://github.com/eclipse/paho.mqtt.golang/blob/54b5153cb955d512bc82f56455769e61ca3d21e9/netconn.go#L34):
* `ws`
* `wss`
* `mqtt`/`tcp`
* `ssl`/`tls`/`mqtts`/`mqtt+ssl`/`tcps`
* `unix`

Moreover, the only *official* mention of scheme I found, it's [on the mqtt.org wiki](https://github.com/mqtt/mqtt.org/wiki/URI-Scheme#scheme) and seem to prefer `mqtt`/`mqtts` over `tcp`/`ssl`

IMO I prefer `mqtt` over `tcp` since it's less technical and more explicit for the user :man_shrugging: 