### PR TITLE
Add "--list" parameter to dump the database

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -111,6 +111,12 @@ func main() {
 		log.Fatal().Err(err).Msgf("Cannot initialize %s", meta.Name)
 	}
 
+    // List images
+    if cli.List {
+        diun.List()
+        return
+    }
+
 	// Test notif
 	if cli.TestNotif {
 		diun.TestNotif()

--- a/internal/app/diun.go
+++ b/internal/app/diun.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"encoding/json"
 	"net/url"
 	"sync"
 	"sync/atomic"
@@ -175,6 +176,27 @@ func (di *Diun) Close() {
 	if err := di.db.Close(); err != nil {
 		log.Warn().Err(err).Msg("Cannot close database")
 	}
+}
+
+// List show all checked images
+func (di *Diun) List() {
+  manifests, err := di.db.GetAllManifests()
+  if err != nil {
+    log.Error().Err(err).Msg("Failed to get manifests")
+    return
+  }
+
+  for _, manifest := range manifests {
+    jsonStr, err := json.Marshal(manifest)
+    if err != nil {
+      log.Error().Err(err).Msg("Could not marshal JSON")
+      return
+    }
+
+    log.Info().RawJSON("manifest", jsonStr).Msg("")
+  }
+  
+  log.Info().Int("manifests", len(manifests)).Msg("List all manifests")
 }
 
 // TestNotif test the notification settings

--- a/internal/db/manifest.go
+++ b/internal/db/manifest.go
@@ -51,3 +51,25 @@ func (c *Client) PutManifest(image registry.Image, manifest registry.Manifest) e
 
 	return err
 }
+
+// GetAllManifests returns a list of all Docker image manifests
+func (c *Client) GetAllManifests() ([]registry.Manifest, error) {
+	tx, err := c.Begin(true)
+	if err != nil {
+		return nil, err
+	}
+
+    var manifests []registry.Manifest
+
+	bucket := tx.Bucket([]byte(bucketManifest))
+	curs := bucket.Cursor()
+	for k, v := curs.First(); k != nil; k, v = curs.Next() {
+		var manifest registry.Manifest
+		if err := json.Unmarshal(v, &manifest); err != nil {
+			return nil, err
+		}
+        manifests = append(manifests, manifest)
+	}
+
+    return manifests, err
+}

--- a/internal/model/cli.go
+++ b/internal/model/cli.go
@@ -13,4 +13,5 @@ type Cli struct {
 	LogCaller    bool   `kong:"name='log-caller',env='LOG_CALLER',default='false',help='Add file:line of the caller to log output.'"`
 	LogNoColor   bool   `kong:"name='log-nocolor',env='LOG_NOCOLOR',default='false',help='Disables the colorized output.'"`
 	TestNotif    bool   `kong:"name='test-notif',default='false',help='Test notification settings.'"`
+    List         bool   `kong:"name='list',default='false',help='List all images that are being checked.'"`
 }


### PR DESCRIPTION
After this change, running "diun --list" outputs the current state of all manifests in the
database.

Addresses #138