### PR TITLE
Adds tzdata to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ FROM alpine:3.14
 RUN apk --update --no-cache add \
     ca-certificates \
     openssl \
+    tzdata \
   && rm -rf /tmp/* /var/cache/apk/*
 
 COPY --from=build /usr/local/bin/diun /usr/local/bin/diun


### PR DESCRIPTION
The container is ignoring the TZ environment variable. Adding tzdata to the container remedies this.