### PR TITLE
Explain roles required for rocketchat notification

### DIFF
--- a/docs/notif/rocketchat.md
+++ b/docs/notif/rocketchat.md
@@ -33,6 +33,8 @@ Allow sending notifications to your Rocket.Chat channel.
 
 !!! warning
     You must first create a _Personal Access Token_ through your account settings on your Rocket.Chat instance.
+    Additionally, your user **must** have the `bot` role.
+    Else, the notifications won't work since they contain `alias` and `avatar` properties (see this [reference](https://developer.rocket.chat/reference/api/rest-api/endpoints/team-collaboration-endpoints/chat-endpoints/postmessage#important) for details).
 
 !!! abstract "Environment variables"
     * `DIUN_NOTIF_ROCKETCHAT_ENDPOINT`


### PR DESCRIPTION
It took me quite some time to debug why I don't get notifications in rocketchat.
Finally, I found that the user must have the `bot` role, since the notifications use `alias` propoerties.
See https://developer.rocket.chat/reference/api/rest-api/endpoints/team-collaboration-endpoints/chat-endpoints/postmessage#important for reference.

I added this information to the rocketchat docs.