### PR TITLE
Use OCI image.url label to override hub link

### DIFF
--- a/internal/app/job.go
+++ b/internal/app/job.go
@@ -197,6 +197,10 @@ func (di *Diun) runJob(job model.Job) (entry model.NotifEntry) {
 		return
 	}
 
+	if v, ok := entry.Manifest.Labels["org.opencontainers.image.url"]; ok {
+		entry.Image.HubLink = v
+	}
+
 	if len(dbManifest.Name) == 0 {
 		entry.Status = model.ImageStatusNew
 		sublog.Info().Msg("New image found")


### PR DESCRIPTION
fixes #562

Override hub link using the [`org.opencontainers.image.url` label](https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys) if found in the manifest.