### PR TITLE
Fix `sort_tags`

### DIFF
--- a/docs/providers/docker.md
+++ b/docs/providers/docker.md
@@ -178,7 +178,7 @@ You can configure more finely the way to analyze the image of your container thr
 | `diun.regopt`       |              | [Registry options](../config/regopts.md) name to use                                                                                                       |
 | `diun.watch_repo`   | `false`      | Watch all tags of this container image ([be careful](../faq.md#docker-hub-rate-limits) with this setting)                                                  |
 | `diun.notify_on`    | `new;update` | Semicolon separated list of status to be notified: `new`, `update`                                                                                         |
-| `diun.sort_tags`    | `reverse`    | [Sort tags method](../faq.md#tags-sorting-when-using-watch_repo) if `diun.watch_repo` enabled. One of `default`, `reverse`, `numerical`, `lexicographical` |
+| `diun.sort_tags`    | `reverse`    | [Sort tags method](../faq.md#tags-sorting-when-using-watch_repo) if `diun.watch_repo` enabled. One of `default`, `reverse`, `semver`, `lexicographical` |
 | `diun.max_tags`     | `0`          | Maximum number of tags to watch if `diun.watch_repo` enabled. `0` means all of them                                                                        |
 | `diun.include_tags` |              | Semicolon separated list of regular expressions to include tags. Can be useful if you enable `diun.watch_repo`                                             |
 | `diun.exclude_tags` |              | Semicolon separated list of regular expressions to exclude tags. Can be useful if you enable `diun.watch_repo`                                             |

--- a/docs/providers/dockerfile.md
+++ b/docs/providers/dockerfile.md
@@ -111,7 +111,7 @@ The following annotations can be added as comments before the target instruction
 | `diun.regopt`       |              | [Registry options](../config/regopts.md) name to use                                                                                                       |
 | `diun.watch_repo`   | `false`      | Watch all tags of this image                                                                                                                               |
 | `diun.notify_on`    | `new;update` | Semicolon separated list of status to be notified: `new`, `update`                                                                                         |
-| `diun.sort_tags`    | `reverse`    | [Sort tags method](../faq.md#tags-sorting-when-using-watch_repo) if `diun.watch_repo` enabled. One of `default`, `reverse`, `numerical`, `lexicographical` |
+| `diun.sort_tags`    | `reverse`    | [Sort tags method](../faq.md#tags-sorting-when-using-watch_repo) if `diun.watch_repo` enabled. One of `default`, `reverse`, `semver`, `lexicographical` |
 | `diun.max_tags`     | `0`          | Maximum number of tags to watch if `watch_repo` enabled. `0` means all of them                                                                             |
 | `diun.include_tags` |              | Semicolon separated list of regular expressions to include tags. Can be useful if you enable `diun.watch_repo`                                             |
 | `diun.exclude_tags` |              | Semicolon separated list of regular expressions to exclude tags. Can be useful if you enable `diun.watch_repo`                                             |

--- a/docs/providers/file.md
+++ b/docs/providers/file.md
@@ -178,7 +178,7 @@ The configuration file(s) defines a slice of images to analyze with the followin
 | `regopt`           |              | [Registry options](../config/regopts.md) name to use                                                                                                       |
 | `watch_repo`       | `false`      | Watch all tags of this image ([be careful](../faq.md#docker-hub-rate-limits) with this setting)                                                            |
 | `notify_on`        | `new;update` | Semicolon separated list of status to be notified: `new`, `update`                                                                                         |
-| `sort_tags`        | `reverse`    | [Sort tags method](../faq.md#tags-sorting-when-using-watch_repo) if `diun.watch_repo` enabled. One of `default`, `reverse`, `numerical`, `lexicographical` |
+| `sort_tags`        | `reverse`    | [Sort tags method](../faq.md#tags-sorting-when-using-watch_repo) if `diun.watch_repo` enabled. One of `default`, `reverse`, `semver`, `lexicographical` |
 | `max_tags`         | `0`          | Maximum number of tags to watch if `watch_repo` enabled. `0` means all of them                                                                             |
 | `include_tags`     |              | List of regular expressions to include tags. Can be useful if you enable `watch_repo`                                                                      |
 | `exclude_tags`     |              | List of regular expressions to exclude tags. Can be useful if you enable `watch_repo`                                                                      |

--- a/docs/providers/kubernetes.md
+++ b/docs/providers/kubernetes.md
@@ -286,7 +286,7 @@ You can configure more finely the way to analyze the image of your pods through 
 | `diun.regopt`       |              | [Registry options](../config/regopts.md) name to use                                                                                                       |
 | `diun.watch_repo`   | `false`      | Watch all tags of this pod image ([be careful](../faq.md#docker-hub-rate-limits) with this setting)                                                        |
 | `diun.notify_on`    | `new;update` | Semicolon separated list of status to be notified: `new`, `update`.                                                                                        |
-| `diun.sort_tags`    | `reverse`    | [Sort tags method](../faq.md#tags-sorting-when-using-watch_repo) if `diun.watch_repo` enabled. One of `default`, `reverse`, `numerical`, `lexicographical` |
+| `diun.sort_tags`    | `reverse`    | [Sort tags method](../faq.md#tags-sorting-when-using-watch_repo) if `diun.watch_repo` enabled. One of `default`, `reverse`, `semver`, `lexicographical` |
 | `diun.max_tags`     | `0`          | Maximum number of tags to watch if `diun.watch_repo` enabled. `0` means all of them                                                                        |
 | `diun.include_tags` |              | Semicolon separated list of regular expressions to include tags. Can be useful if you enable `diun.watch_repo`                                             |
 | `diun.exclude_tags` |              | Semicolon separated list of regular expressions to exclude tags. Can be useful if you enable `diun.watch_repo`                                             |

--- a/docs/providers/swarm.md
+++ b/docs/providers/swarm.md
@@ -180,7 +180,7 @@ You can configure more finely the way to analyze the image of your service throu
 | `diun.regopt`       |              | [Registry options](../config/regopts.md) name to use                                                                                                       |
 | `diun.watch_repo`   | `false`      | Watch all tags of this service image ([be careful](../faq.md#docker-hub-rate-limits) with this setting)                                                    |
 | `diun.notify_on`    | `new;update` | Semicolon separated list of status to be notified: `new`, `update`.                                                                                        |
-| `diun.sort_tags`    | `reverse`    | [Sort tags method](../faq.md#tags-sorting-when-using-watch_repo) if `diun.watch_repo` enabled. One of `default`, `reverse`, `numerical`, `lexicographical` |
+| `diun.sort_tags`    | `reverse`    | [Sort tags method](../faq.md#tags-sorting-when-using-watch_repo) if `diun.watch_repo` enabled. One of `default`, `reverse`, `semver`, `lexicographical` |
 | `diun.max_tags`     | `0`          | Maximum number of tags to watch if `diun.watch_repo` enabled. `0` means all of them                                                                        |
 | `diun.include_tags` |              | Semicolon separated list of regular expressions to include tags. Can be useful if you enable `diun.watch_repo`                                             |
 | `diun.exclude_tags` |              | Semicolon separated list of regular expressions to exclude tags. Can be useful if you enable `diun.watch_repo`                                             |


### PR DESCRIPTION
We don't have `numerical` for sort tags type. It should be `semver`