### PR TITLE
Introduce capture groups in `include_tags`

### DIFF
--- a/docs/providers/docker.md
+++ b/docs/providers/docker.md
@@ -173,14 +173,14 @@ Include created and exited containers too (default `false`).
 You can configure more finely the way to analyze the image of your container through Docker labels:
 
 | Name                | Default      | Description                                                                                                                                                |
-|---------------------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `diun.enable`       |              | Set to true to enable image analysis of this container                                                                                                     |
-| `diun.regopt`       |              | [Registry options](../config/regopts.md) name to use                                                                                                       |
-| `diun.watch_repo`   | `false`      | Watch all tags of this container image ([be careful](../faq.md#docker-hub-rate-limits) with this setting)                                                  |
-| `diun.notify_on`    | `new;update` | Semicolon separated list of status to be notified: `new`, `update`                                                                                         |
-| `diun.sort_tags`    | `reverse`    | [Sort tags method](../faq.md#tags-sorting-when-using-watch_repo) if `diun.watch_repo` enabled. One of `default`, `reverse`, `semver`, `lexicographical` |
-| `diun.max_tags`     | `0`          | Maximum number of tags to watch if `diun.watch_repo` enabled. `0` means all of them                                                                        |
-| `diun.include_tags` |              | Semicolon separated list of regular expressions to include tags. Can be useful if you enable `diun.watch_repo`                                             |
-| `diun.exclude_tags` |              | Semicolon separated list of regular expressions to exclude tags. Can be useful if you enable `diun.watch_repo`                                             |
-| `diun.hub_link`     | _automatic_  | Set registry hub link for this image                                                                                                                       |
-| `diun.platform`     | _automatic_  | Platform to use (e.g. `linux/amd64`)                                                                                                                       |
+|---------------------|--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `diun.enable`       |              | Set to true to enable image analysis of this container                                                                                                                  |
+| `diun.regopt`       |              | [Registry options](../config/regopts.md) name to use                                                                                                                    |
+| `diun.watch_repo`   | `false`      | Watch all tags of this container image ([be careful](../faq.md#docker-hub-rate-limits) with this setting)                                                               |
+| `diun.notify_on`    | `new;update` | Semicolon separated list of status to be notified: `new`, `update`                                                                                                      |
+| `diun.sort_tags`    | `reverse`    | [Sort tags method](../faq.md#tags-sorting-when-using-watch_repo) if `diun.watch_repo` enabled. One of `default`, `reverse`, `semver`, `lexicographical`                 |
+| `diun.max_tags`     | `0`          | Maximum number of tags to watch if `diun.watch_repo` enabled. `0` means all of them                                                                                     |
+| `diun.include_tags` |              | Semicolon separated list of regular expressions to include tags. When using capture groups, only these will be processed. Can be useful if you enable `diun.watch_repo` |
+| `diun.exclude_tags` |              | Semicolon separated list of regular expressions to exclude tags. Can be useful if you enable `diun.watch_repo`                                                          |
+| `diun.hub_link`     | _automatic_  | Set registry hub link for this image                                                                                                                                    |
+| `diun.platform`     | _automatic_  | Platform to use (e.g. `linux/amd64`)                                                                                                                                    |

--- a/docs/providers/dockerfile.md
+++ b/docs/providers/dockerfile.md
@@ -107,13 +107,13 @@ List of path patterns with [matching and globbing supporting patterns](https://g
 The following annotations can be added as comments before the target instruction to customize the image analysis:
 
 | Name                | Default      | Description                                                                                                                                                |
-|---------------------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `diun.regopt`       |              | [Registry options](../config/regopts.md) name to use                                                                                                       |
-| `diun.watch_repo`   | `false`      | Watch all tags of this image                                                                                                                               |
-| `diun.notify_on`    | `new;update` | Semicolon separated list of status to be notified: `new`, `update`                                                                                         |
-| `diun.sort_tags`    | `reverse`    | [Sort tags method](../faq.md#tags-sorting-when-using-watch_repo) if `diun.watch_repo` enabled. One of `default`, `reverse`, `semver`, `lexicographical` |
-| `diun.max_tags`     | `0`          | Maximum number of tags to watch if `watch_repo` enabled. `0` means all of them                                                                             |
-| `diun.include_tags` |              | Semicolon separated list of regular expressions to include tags. Can be useful if you enable `diun.watch_repo`                                             |
-| `diun.exclude_tags` |              | Semicolon separated list of regular expressions to exclude tags. Can be useful if you enable `diun.watch_repo`                                             |
-| `diun.hub_link`     | _automatic_  | Set registry hub link for this image                                                                                                                       |
-| `diun.platform`     | _automatic_  | Platform to use (e.g. `linux/amd64`)                                                                                                                       |
+|---------------------|--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `diun.regopt`       |              | [Registry options](../config/regopts.md) name to use                                                                                                                    |
+| `diun.watch_repo`   | `false`      | Watch all tags of this image                                                                                                                                            |
+| `diun.notify_on`    | `new;update` | Semicolon separated list of status to be notified: `new`, `update`                                                                                                      |
+| `diun.sort_tags`    | `reverse`    | [Sort tags method](../faq.md#tags-sorting-when-using-watch_repo) if `diun.watch_repo` enabled. One of `default`, `reverse`, `semver`, `lexicographical`                 |
+| `diun.max_tags`     | `0`          | Maximum number of tags to watch if `watch_repo` enabled. `0` means all of them                                                                                          |
+| `diun.include_tags` |              | Semicolon separated list of regular expressions to include tags. When using capture groups, only these will be processed. Can be useful if you enable `diun.watch_repo` |
+| `diun.exclude_tags` |              | Semicolon separated list of regular expressions to exclude tags. Can be useful if you enable `diun.watch_repo`                                                          |
+| `diun.hub_link`     | _automatic_  | Set registry hub link for this image                                                                                                                                    |
+| `diun.platform`     | _automatic_  | Platform to use (e.g. `linux/amd64`)                                                                                                                                    |

--- a/docs/providers/kubernetes.md
+++ b/docs/providers/kubernetes.md
@@ -281,14 +281,14 @@ Enable watch by default. If false, pods that don't have `diun.enable: "true"` an
 You can configure more finely the way to analyze the image of your pods through Kubernetes annotations:
 
 | Name                | Default      | Description                                                                                                                                                |
-|---------------------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `diun.enable`       |              | Set to true to enable image analysis of this pod                                                                                                           |
-| `diun.regopt`       |              | [Registry options](../config/regopts.md) name to use                                                                                                       |
-| `diun.watch_repo`   | `false`      | Watch all tags of this pod image ([be careful](../faq.md#docker-hub-rate-limits) with this setting)                                                        |
-| `diun.notify_on`    | `new;update` | Semicolon separated list of status to be notified: `new`, `update`.                                                                                        |
-| `diun.sort_tags`    | `reverse`    | [Sort tags method](../faq.md#tags-sorting-when-using-watch_repo) if `diun.watch_repo` enabled. One of `default`, `reverse`, `semver`, `lexicographical` |
-| `diun.max_tags`     | `0`          | Maximum number of tags to watch if `diun.watch_repo` enabled. `0` means all of them                                                                        |
-| `diun.include_tags` |              | Semicolon separated list of regular expressions to include tags. Can be useful if you enable `diun.watch_repo`                                             |
-| `diun.exclude_tags` |              | Semicolon separated list of regular expressions to exclude tags. Can be useful if you enable `diun.watch_repo`                                             |
-| `diun.hub_link`     | _automatic_  | Set registry hub link for this image                                                                                                                       |
-| `diun.platform`     | _automatic_  | Platform to use (e.g. `linux/amd64`)                                                                                                                       |
+|---------------------|--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `diun.enable`       |              | Set to true to enable image analysis of this pod                                                                                                                        |
+| `diun.regopt`       |              | [Registry options](../config/regopts.md) name to use                                                                                                                    |
+| `diun.watch_repo`   | `false`      | Watch all tags of this pod image ([be careful](../faq.md#docker-hub-rate-limits) with this setting)                                                                     |
+| `diun.notify_on`    | `new;update` | Semicolon separated list of status to be notified: `new`, `update`.                                                                                                     |
+| `diun.sort_tags`    | `reverse`    | [Sort tags method](../faq.md#tags-sorting-when-using-watch_repo) if `diun.watch_repo` enabled. One of `default`, `reverse`, `semver`, `lexicographical`                 |
+| `diun.max_tags`     | `0`          | Maximum number of tags to watch if `diun.watch_repo` enabled. `0` means all of them                                                                                     |
+| `diun.include_tags` |              | Semicolon separated list of regular expressions to include tags. When using capture groups, only these will be processed. Can be useful if you enable `diun.watch_repo` |
+| `diun.exclude_tags` |              | Semicolon separated list of regular expressions to exclude tags. Can be useful if you enable `diun.watch_repo`                                                          |
+| `diun.hub_link`     | _automatic_  | Set registry hub link for this image                                                                                                                                    |
+| `diun.platform`     | _automatic_  | Platform to use (e.g. `linux/amd64`)                                                                                                                                    |

--- a/docs/providers/swarm.md
+++ b/docs/providers/swarm.md
@@ -175,14 +175,14 @@ Enable watch by default. If false, services that don't have `diun.enable=true` l
 You can configure more finely the way to analyze the image of your service through Docker labels:
 
 | Name                | Default      | Description                                                                                                                                                |
-|---------------------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `diun.enable`       |              | Set to true to enable image analysis of this service                                                                                                       |
-| `diun.regopt`       |              | [Registry options](../config/regopts.md) name to use                                                                                                       |
-| `diun.watch_repo`   | `false`      | Watch all tags of this service image ([be careful](../faq.md#docker-hub-rate-limits) with this setting)                                                    |
-| `diun.notify_on`    | `new;update` | Semicolon separated list of status to be notified: `new`, `update`.                                                                                        |
-| `diun.sort_tags`    | `reverse`    | [Sort tags method](../faq.md#tags-sorting-when-using-watch_repo) if `diun.watch_repo` enabled. One of `default`, `reverse`, `semver`, `lexicographical` |
-| `diun.max_tags`     | `0`          | Maximum number of tags to watch if `diun.watch_repo` enabled. `0` means all of them                                                                        |
-| `diun.include_tags` |              | Semicolon separated list of regular expressions to include tags. Can be useful if you enable `diun.watch_repo`                                             |
-| `diun.exclude_tags` |              | Semicolon separated list of regular expressions to exclude tags. Can be useful if you enable `diun.watch_repo`                                             |
-| `diun.hub_link`     | _automatic_  | Set registry hub link for this image                                                                                                                       |
-| `diun.platform`     | _automatic_  | Platform to use (e.g. `linux/amd64`)                                                                                                                       |
+|---------------------|--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `diun.enable`       |              | Set to true to enable image analysis of this service                                                                                                                    |
+| `diun.regopt`       |              | [Registry options](../config/regopts.md) name to use                                                                                                                    |
+| `diun.watch_repo`   | `false`      | Watch all tags of this service image ([be careful](../faq.md#docker-hub-rate-limits) with this setting)                                                                 |
+| `diun.notify_on`    | `new;update` | Semicolon separated list of status to be notified: `new`, `update`.                                                                                                     |
+| `diun.sort_tags`    | `reverse`    | [Sort tags method](../faq.md#tags-sorting-when-using-watch_repo) if `diun.watch_repo` enabled. One of `default`, `reverse`, `semver`, `lexicographical`                 |
+| `diun.max_tags`     | `0`          | Maximum number of tags to watch if `diun.watch_repo` enabled. `0` means all of them                                                                                     |
+| `diun.include_tags` |              | Semicolon separated list of regular expressions to include tags. When using capture groups, only these will be processed. Can be useful if you enable `diun.watch_repo` |
+| `diun.exclude_tags` |              | Semicolon separated list of regular expressions to exclude tags. Can be useful if you enable `diun.watch_repo`                                                          |
+| `diun.hub_link`     | _automatic_  | Set registry hub link for this image                                                                                                                                    |
+| `diun.platform`     | _automatic_  | Platform to use (e.g. `linux/amd64`)                                                                                                                                    |

--- a/pkg/registry/tags.go
+++ b/pkg/registry/tags.go
@@ -44,6 +44,9 @@ func (c *Client) Tags(opts TagsOptions) (*Tags, error) {
 		Total:       len(tags),
 	}
 
+	// Filter tags
+	tags = ExtractVersions(tags, opts.Include)
+
 	// Sort tags
 	tags = SortTags(tags, opts.Sort)
 

--- a/pkg/registry/tags_sort.go
+++ b/pkg/registry/tags_sort.go
@@ -5,8 +5,20 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/crazy-max/diun/v4/pkg/utl"
 	"golang.org/x/mod/semver"
 )
+
+// ExtractVersions extracts versions from tags using capture groups if applicable
+func ExtractVersions(tags, includes []string) []string {
+	for _, include := range includes {
+		for t, tag := range tags {
+			tags[t] = utl.ExtractCaptureRegex(tag, include)
+		}
+	}
+
+	return tags
+}
 
 // SortTags sorts tags list
 func SortTags(tags []string, sortTag SortTag) []string {

--- a/pkg/registry/tags_test.go
+++ b/pkg/registry/tags_test.go
@@ -28,6 +28,19 @@ func TestTags(t *testing.T) {
 	assert.True(t, len(tags.List) > 0)
 }
 
+func TestTagsExtraction(t *testing.T) {
+	repotags := []string{
+		"latest",
+		"v-1.0.0",
+		"version-1.1.0",
+		"v-1.2.0",
+		"version-1.2.3",
+	}
+
+	tags := registry.ExtractVersions(repotags, []string{`(v)-(\d+\.\d+\.\d+)`, `version-(\d+\.\d+\.\d+)`})
+	assert.Equal(t, []string{"latest", "v1.0.0", "1.1.0", "v1.2.0", "1.2.3"}, tags)
+}
+
 func TestTagsSort(t *testing.T) {
 	repotags := []string{
 		"0.1.0",

--- a/pkg/utl/utl.go
+++ b/pkg/utl/utl.go
@@ -3,6 +3,7 @@ package utl
 import (
 	"os"
 	"regexp"
+	"strings"
 	"time"
 )
 
@@ -92,4 +93,21 @@ func Contains(s []string, e string) bool {
 		}
 	}
 	return false
+}
+
+// ExtractCaptureRegex extracts capture regex if capture groups are defined, if not it returns original string
+func ExtractCaptureRegex(source, regex string) string {
+	re, err := regexp.Compile(regex)
+
+	if err != nil {
+		return source
+	}
+
+	result := re.FindStringSubmatch(source)
+
+	if len(result) > 1 {
+		return strings.Join(result[1:(len(result))], "")
+	}
+
+	return source
 }

--- a/pkg/utl/utl_test.go
+++ b/pkg/utl/utl_test.go
@@ -1,0 +1,16 @@
+package utl_test
+
+import (
+	"testing"
+
+	"github.com/crazy-max/diun/v4/pkg/utl"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractCaptureRegex(t *testing.T) {
+	assert.Equal(t, "version-1.2.3", utl.ExtractCaptureRegex("version-1.2.3", "^not-matching-regex$"))
+	assert.Equal(t, "version-1.2.3", utl.ExtractCaptureRegex("version-1.2.3", `version-1\.2\.3`))
+	assert.Equal(t, "v1.2.3", utl.ExtractCaptureRegex("version-1.2.3", `(v)ersion-(1\.2\.3)`))
+	assert.Equal(t, "1.2.3", utl.ExtractCaptureRegex("version-1.2.3", `version-(1\.2\.3)`))
+	assert.Equal(t, "1.2.3", utl.ExtractCaptureRegex("version-1.2.3", `^version-(1\.2\.3)$`))
+}


### PR DESCRIPTION
This is an attempt, to solve the problem, that most docker tags does not follow semver very well (to say it lightly). By using capture groups in `include_tags` we can extract only version portion, and process it further. For example `fireflyiii/core` image follows this version format:

```
version-5.7.10
version-5.7.9
...
version-5.7
```

Semver gets dizzy here, but the version is there, just in wrong format. This PR adds a way, to partialy solve this problem, by introducing capture groups. To support these tags, `include_tags: "^version-(\d+\.\d+\.\d*)$` should be used. It would extract the version (`5.7.10`, `5.7.9` etc.), and then process it further (sort, limit etc.).

Multiple capture groups are also valid - they will be concatenated, so for example `include_tags: "^(v)ersion-(\d+\.\d+\.\d*)"` would return `v5.7.10`, `v5.7.9` etc.