### PR TITLE
Correct the issues URL

### DIFF
--- a/docs/reporting-issue.md
+++ b/docs/reporting-issue.md
@@ -4,7 +4,7 @@
 
 First, [be a good guy](https://github.com/kossnocorp/etiquette/blob/master/README.md).
 
-Please do a search in [open issues]([[ config.repo_url ]]issues?utf8=%E2%9C%93&q=) to see if the issue or feature request has already been filed and read the [FAQ](faq.md) page first.
+Please do a search in [open issues]([[ config.repo_url ]]/issues?utf8=%E2%9C%93) to see if the issue or feature request has already been filed and read the [FAQ](faq.md) page first.
 
 If you find your issue already exists, make relevant comments and add your [reaction](https://github.com/blog/2119-add-reactions-to-pull-requests-issues-and-comments). Use a reaction in place of a "+1" comment.
 


### PR DESCRIPTION
The repo_url does not contain a trailing slash, so the link is a 404, and with the `q=` query in the URL it searches all Issues & PRs which is not what I think is wanted.

Current URL: https://github.com/crazy-max/diunissues?utf8=%E2%9C%93&q=
New URL: https://github.com/crazy-max/diun/issues?utf8=%E2%9C%93