### PR TITLE
WIP: Global defaults for image configs

### DIFF
--- a/internal/app/diun.go
+++ b/internal/app/diun.go
@@ -152,32 +152,32 @@ func (di *Diun) Run() {
 	defer di.pool.Release()
 
 	// Docker provider
-	for _, job := range dockerPrd.New(di.cfg.Providers.Docker).ListJob() {
+	for _, job := range dockerPrd.New(di.cfg.Providers.Docker, di.cfg.Watch.ImageDefaults).ListJob() {
 		di.createJob(job)
 	}
 
 	// Swarm provider
-	for _, job := range swarmPrd.New(di.cfg.Providers.Swarm).ListJob() {
+	for _, job := range swarmPrd.New(di.cfg.Providers.Swarm, di.cfg.Watch.ImageDefaults).ListJob() {
 		di.createJob(job)
 	}
 
 	// Kubernetes provider
-	for _, job := range kubernetesPrd.New(di.cfg.Providers.Kubernetes).ListJob() {
+	for _, job := range kubernetesPrd.New(di.cfg.Providers.Kubernetes, di.cfg.Watch.ImageDefaults).ListJob() {
 		di.createJob(job)
 	}
 
 	// File provider
-	for _, job := range filePrd.New(di.cfg.Providers.File).ListJob() {
+	for _, job := range filePrd.New(di.cfg.Providers.File, di.cfg.Watch.ImageDefaults).ListJob() {
 		di.createJob(job)
 	}
 
 	// Dockerfile provider
-	for _, job := range dockerfilePrd.New(di.cfg.Providers.Dockerfile).ListJob() {
+	for _, job := range dockerfilePrd.New(di.cfg.Providers.Dockerfile, di.cfg.Watch.ImageDefaults).ListJob() {
 		di.createJob(job)
 	}
 
 	// Nomad provider
-	for _, job := range nomadPrd.New(di.cfg.Providers.Nomad).ListJob() {
+	for _, job := range nomadPrd.New(di.cfg.Providers.Nomad, di.cfg.Watch.ImageDefaults).ListJob() {
 		di.createJob(job)
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/crazy-max/diun/v4/internal/config"
 	"github.com/crazy-max/diun/v4/internal/model"
+	"github.com/crazy-max/diun/v4/pkg/registry"
 	"github.com/crazy-max/diun/v4/pkg/utl"
 	"github.com/crazy-max/gonfig/env"
 	"github.com/stretchr/testify/assert"
@@ -58,6 +59,10 @@ func TestLoadFile(t *testing.T) {
 					Healthchecks: &model.Healthchecks{
 						BaseURL: "https://hc-ping.com/",
 						UUID:    "5bf66975-d4c7-4bf5-bcc8-b8d8a82ea278",
+					},
+					ImageDefaults: &model.Image{
+						NotifyOn: model.NotifyOnDefaults,
+						SortTags: registry.SortTagReverse,
 					},
 				},
 				Notif: &model.Notif{

--- a/internal/model/watch.go
+++ b/internal/model/watch.go
@@ -3,6 +3,7 @@ package model
 import (
 	"time"
 
+	"github.com/crazy-max/diun/v4/pkg/registry"
 	"github.com/crazy-max/diun/v4/pkg/utl"
 )
 
@@ -14,6 +15,7 @@ type Watch struct {
 	FirstCheckNotif *bool          `yaml:"firstCheckNotif,omitempty" json:"firstCheckNotif,omitempty" validate:"required"`
 	CompareDigest   *bool          `yaml:"compareDigest,omitempty" json:"compareDigest,omitempty" validate:"required"`
 	Healthchecks    *Healthchecks  `yaml:"healthchecks,omitempty" json:"healthchecks,omitempty"`
+	ImageDefaults   *Image         `yaml:"defaults,omitempty" json:"defaults,omitempty"`
 }
 
 // GetDefaults gets the default values
@@ -29,4 +31,8 @@ func (s *Watch) SetDefaults() {
 	s.Jitter = utl.NewDuration(30 * time.Second)
 	s.FirstCheckNotif = utl.NewFalse()
 	s.CompareDigest = utl.NewTrue()
+	s.ImageDefaults = &Image{
+		NotifyOn: NotifyOnDefaults,
+		SortTags: registry.SortTagReverse,
+	}
 }

--- a/internal/provider/common.go
+++ b/internal/provider/common.go
@@ -18,16 +18,14 @@ var (
 )
 
 // ValidateImage returns a standard image through Docker labels
-func ValidateImage(image string, metadata, labels map[string]string, watchByDef bool) (img model.Image, err error) {
+func ValidateImage(image string, metadata, labels map[string]string, watchByDef bool, imageDefaults model.Image) (img model.Image, err error) {
 	if i := strings.Index(image, "@sha256:"); i > 0 {
 		image = image[:i]
 	}
-	img = model.Image{
-		Name:     image,
-		Metadata: metadata,
-		NotifyOn: model.NotifyOnDefaults,
-		SortTags: registry.SortTagReverse,
-	}
+
+	img = imageDefaults
+	img.Name = image
+	img.Metadata = metadata
 
 	if enableStr, ok := labels["diun.enable"]; ok {
 		enable, err := strconv.ParseBool(enableStr)

--- a/internal/provider/common_test.go
+++ b/internal/provider/common_test.go
@@ -1,0 +1,89 @@
+package provider_test
+
+import (
+	"testing"
+
+	"github.com/crazy-max/diun/v4/internal/model"
+	"github.com/crazy-max/diun/v4/internal/provider"
+	"github.com/crazy-max/diun/v4/pkg/registry"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateImage(t *testing.T) {
+	cases := []struct {
+		name          string
+		image         string
+		metadata      map[string]string
+		labels        map[string]string
+		watchByDef    bool
+		imageDefaults model.Image
+		expectedImage model.Image
+		expectedErr   error
+	}{
+
+		{
+			name:          "All excluded by default",
+			image:         "myimg",
+			expectedImage: model.Image{},
+			expectedErr:   nil,
+		},
+		{
+			name:       "Include using watch by default",
+			image:      "myimg",
+			watchByDef: true,
+			expectedImage: model.Image{
+				Name: "myimg",
+			},
+			expectedErr: nil,
+		},
+		{
+			name:       "Include using global settings",
+			image:      "myimg",
+			watchByDef: true,
+			imageDefaults: model.Image{
+				WatchRepo: true,
+				SortTags:  registry.SortTagSemver,
+			},
+			expectedImage: model.Image{
+				Name:      "myimg",
+				WatchRepo: true,
+				SortTags:  registry.SortTagSemver,
+			},
+			expectedErr: nil,
+		},
+		{
+			name:       "Override default image values with labels",
+			image:      "myimg",
+			watchByDef: true,
+			labels: map[string]string{
+				"diun.watch_repo": "false",
+			},
+			imageDefaults: model.Image{
+				WatchRepo: true,
+				SortTags:  registry.SortTagSemver,
+			},
+			expectedImage: model.Image{
+				Name:      "myimg",
+				WatchRepo: false,
+				SortTags:  registry.SortTagSemver,
+			},
+			expectedErr: nil,
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			actualImg, actualErr := provider.ValidateImage(
+				c.image,
+				c.metadata,
+				c.labels,
+				c.watchByDef,
+				c.imageDefaults,
+			)
+			assert.Equal(t, c.expectedImage, actualImg)
+			assert.Equal(t, c.expectedErr, actualErr)
+		})
+	}
+}

--- a/internal/provider/docker/container.go
+++ b/internal/provider/docker/container.go
@@ -91,7 +91,7 @@ func (c *Client) listContainerImage() []model.Image {
 			Str("ctn_image", imageName).
 			Interface("ctn_labels", ctn.Labels).
 			Msg("Validate image")
-		image, err := provider.ValidateImage(imageName, metadata(ctn), ctn.Labels, *c.config.WatchByDefault)
+		image, err := provider.ValidateImage(imageName, metadata(ctn), ctn.Labels, *c.config.WatchByDefault, *c.imageDefaults)
 
 		if err != nil {
 			c.logger.Error().Err(err).

--- a/internal/provider/docker/docker.go
+++ b/internal/provider/docker/docker.go
@@ -10,16 +10,18 @@ import (
 // Client represents an active docker provider object
 type Client struct {
 	*provider.Client
-	config *model.PrdDocker
-	logger zerolog.Logger
+	config        *model.PrdDocker
+	logger        zerolog.Logger
+	imageDefaults *model.Image
 }
 
 // New creates new docker provider instance
-func New(config *model.PrdDocker) *provider.Client {
+func New(config *model.PrdDocker, imageDefaults *model.Image) *provider.Client {
 	return &provider.Client{
 		Handler: &Client{
-			config: config,
-			logger: log.With().Str("provider", "docker").Logger(),
+			config:        config,
+			logger:        log.With().Str("provider", "docker").Logger(),
+			imageDefaults: imageDefaults,
 		},
 	}
 }

--- a/internal/provider/dockerfile/dockerfile.go
+++ b/internal/provider/dockerfile/dockerfile.go
@@ -10,16 +10,18 @@ import (
 // Client represents an active dockerfile provider object
 type Client struct {
 	*provider.Client
-	config *model.PrdDockerfile
-	logger zerolog.Logger
+	config        *model.PrdDockerfile
+	logger        zerolog.Logger
+	imageDefaults *model.Image
 }
 
 // New creates new dockerfile provider instance
-func New(config *model.PrdDockerfile) *provider.Client {
+func New(config *model.PrdDockerfile, imageDefaults *model.Image) *provider.Client {
 	return &provider.Client{
 		Handler: &Client{
-			config: config,
-			logger: log.With().Str("provider", "dockerfile").Logger(),
+			config:        config,
+			logger:        log.With().Str("provider", "dockerfile").Logger(),
+			imageDefaults: imageDefaults,
 		},
 	}
 }

--- a/internal/provider/dockerfile/image.go
+++ b/internal/provider/dockerfile/image.go
@@ -32,7 +32,7 @@ func (c *Client) listExtImage() (list []model.Image) {
 				Interface("dfile_comments", fromImage.Comments).
 				Int("dfile_line", fromImage.Line).
 				Msg("Validate image")
-			image, err := provider.ValidateImage(fromImage.Name, nil, c.extractLabels(fromImage.Comments), true)
+			image, err := provider.ValidateImage(fromImage.Name, nil, c.extractLabels(fromImage.Comments), true, *c.imageDefaults)
 			if err != nil {
 				c.logger.Error().Err(err).
 					Str("dfile_image", fromImage.Name).

--- a/internal/provider/file/file.go
+++ b/internal/provider/file/file.go
@@ -10,16 +10,18 @@ import (
 // Client represents an active file provider object
 type Client struct {
 	*provider.Client
-	config *model.PrdFile
-	logger zerolog.Logger
+	config        *model.PrdFile
+	logger        zerolog.Logger
+	imageDefaults *model.Image
 }
 
 // New creates new file provider instance
-func New(config *model.PrdFile) *provider.Client {
+func New(config *model.PrdFile, imageDefaults *model.Image) *provider.Client {
 	return &provider.Client{
 		Handler: &Client{
-			config: config,
-			logger: log.With().Str("provider", "file").Logger(),
+			config:        config,
+			logger:        log.With().Str("provider", "file").Logger(),
+			imageDefaults: imageDefaults,
 		},
 	}
 }

--- a/internal/provider/file/file_test.go
+++ b/internal/provider/file/file_test.go
@@ -10,6 +10,10 @@ import (
 )
 
 var (
+	defaultImageDefaults = &model.Image{
+		NotifyOn: model.NotifyOnDefaults,
+		SortTags: registry.SortTagReverse,
+	}
 	bintrayFile = []model.Job{
 		{
 			Provider: "file",
@@ -153,13 +157,25 @@ var (
 func TestListJobFilename(t *testing.T) {
 	fc := file.New(&model.PrdFile{
 		Filename: "./fixtures/dockerhub.yml",
-	})
+	}, defaultImageDefaults)
 	assert.Equal(t, dockerhubFile, fc.ListJob())
 }
 
 func TestListJobDirectory(t *testing.T) {
 	fc := file.New(&model.PrdFile{
 		Directory: "./fixtures",
-	})
+	}, defaultImageDefaults)
 	assert.Equal(t, append(append(bintrayFile, dockerhubFile...), append(lscrFile, quayFile...)...), fc.ListJob())
 }
+
+/*
+ * func TestDefaultImageOptions(t *testing.T) {
+ * 	fc := file.New(&model.PrdFile{
+ * 		Filename: "./fixtures/dockerhub.yml",
+ * 	}, &model.Image{WatchRepo: true})
+ *
+ * 	for _, job := range fc.ListJob() {
+ * 		assert.True(t, job.Image.WatchRepo)
+ * 	}
+ * }
+ */

--- a/internal/provider/file/image.go
+++ b/internal/provider/file/image.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/containerd/containerd/platforms"
 	"github.com/crazy-max/diun/v4/internal/model"
-	"github.com/crazy-max/diun/v4/pkg/registry"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"gopkg.in/yaml.v2"
 )
@@ -34,7 +33,7 @@ func (c *Client) listFileImage() []model.Image {
 		for _, item := range items {
 			// Check NotifyOn
 			if len(item.NotifyOn) == 0 {
-				item.NotifyOn = model.NotifyOnDefaults
+				item.NotifyOn = c.imageDefaults.NotifyOn
 			} else {
 				for _, no := range item.NotifyOn {
 					if !no.Valid() {
@@ -48,7 +47,7 @@ func (c *Client) listFileImage() []model.Image {
 
 			// Check SortType
 			if item.SortTags == "" {
-				item.SortTags = registry.SortTagReverse
+				item.SortTags = c.imageDefaults.SortTags
 			}
 			if !item.SortTags.Valid() {
 				c.logger.Error().

--- a/internal/provider/kubernetes/kubernetes.go
+++ b/internal/provider/kubernetes/kubernetes.go
@@ -10,16 +10,18 @@ import (
 // Client represents an active kubernetes provider object
 type Client struct {
 	*provider.Client
-	config *model.PrdKubernetes
-	logger zerolog.Logger
+	config        *model.PrdKubernetes
+	logger        zerolog.Logger
+	imageDefaults *model.Image
 }
 
 // New creates new kubernetes provider instance
-func New(config *model.PrdKubernetes) *provider.Client {
+func New(config *model.PrdKubernetes, imageDefaults *model.Image) *provider.Client {
 	return &provider.Client{
 		Handler: &Client{
-			config: config,
-			logger: log.With().Str("provider", "kubernetes").Logger(),
+			config:        config,
+			logger:        log.With().Str("provider", "kubernetes").Logger(),
+			imageDefaults: imageDefaults,
 		},
 	}
 }

--- a/internal/provider/kubernetes/pod.go
+++ b/internal/provider/kubernetes/pod.go
@@ -41,7 +41,7 @@ func (c *Client) listPodImage() []model.Image {
 				Str("ctn_image", ctn.Image).
 				Msg("Validate image")
 
-			image, err := provider.ValidateImage(ctn.Image, metadata(pod, ctn), pod.Annotations, *c.config.WatchByDefault)
+			image, err := provider.ValidateImage(ctn.Image, metadata(pod, ctn), pod.Annotations, *c.config.WatchByDefault, *c.imageDefaults)
 			if err != nil {
 				c.logger.Error().Err(err).
 					Str("pod_name", pod.Name).

--- a/internal/provider/nomad/nomad.go
+++ b/internal/provider/nomad/nomad.go
@@ -10,16 +10,18 @@ import (
 // Client represents an active nomad provider object
 type Client struct {
 	*provider.Client
-	config *model.PrdNomad
-	logger zerolog.Logger
+	config        *model.PrdNomad
+	logger        zerolog.Logger
+	imageDefaults *model.Image
 }
 
-// New creates new kubernetes provider instance
-func New(config *model.PrdNomad) *provider.Client {
+// New creates new nomad provider instance
+func New(config *model.PrdNomad, imageDefaults *model.Image) *provider.Client {
 	return &provider.Client{
 		Handler: &Client{
-			config: config,
-			logger: log.With().Str("provider", "nomad").Logger(),
+			config:        config,
+			logger:        log.With().Str("provider", "nomad").Logger(),
+			imageDefaults: imageDefaults,
 		},
 	}
 }

--- a/internal/provider/nomad/task.go
+++ b/internal/provider/nomad/task.go
@@ -9,7 +9,7 @@ import (
 	nomad "github.com/hashicorp/nomad/api"
 )
 
-func parseServiceTags(tags []string) map[string]string {
+func ParseServiceTags(tags []string) map[string]string {
 	labels := map[string]string{}
 
 	for _, tag := range tags {
@@ -69,7 +69,7 @@ func (c *Client) listTaskImages() []model.Image {
 			groupLabels = updateMap(groupLabels, taskGroup.Meta)
 
 			for _, service := range taskGroup.Services {
-				groupLabels = updateMap(groupLabels, parseServiceTags(service.Tags))
+				groupLabels = updateMap(groupLabels, ParseServiceTags(service.Tags))
 			}
 
 			for _, task := range taskGroup.Tasks {
@@ -92,13 +92,13 @@ func (c *Client) listTaskImages() []model.Image {
 					labels := map[string]string{}
 					labels = updateMap(labels, groupLabels)
 					for _, service := range task.Services {
-						labels = updateMap(labels, parseServiceTags(service.Tags))
+						labels = updateMap(labels, ParseServiceTags(service.Tags))
 					}
 
 					// Finally, merge task meta values
 					labels = updateMap(labels, task.Meta)
 
-					image, err := provider.ValidateImage(imageName, metadata(job, taskGroup, task), labels, *c.config.WatchByDefault)
+					image, err := provider.ValidateImage(imageName, metadata(job, taskGroup, task), labels, *c.config.WatchByDefault, *c.imageDefaults)
 					if err != nil {
 						c.logger.Error().
 							Err(err).

--- a/internal/provider/nomad/task_test.go
+++ b/internal/provider/nomad/task_test.go
@@ -1,8 +1,9 @@
-package nomad
+package nomad_test
 
 import (
 	"testing"
 
+	"github.com/crazy-max/diun/v4/internal/provider/nomad"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -46,7 +47,7 @@ func TestParseServiceTags(t *testing.T) {
 	for _, tt := range testCases {
 		tt := tt
 		t.Run(tt.input[0], func(t *testing.T) {
-			result := parseServiceTags(tt.input)
+			result := nomad.ParseServiceTags(tt.input)
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/internal/provider/swarm/service.go
+++ b/internal/provider/swarm/service.go
@@ -37,7 +37,7 @@ func (c *Client) listServiceImage() []model.Image {
 			Str("ctn_image", svc.Spec.TaskTemplate.ContainerSpec.Image).
 			Msg("Validate image")
 
-		image, err := provider.ValidateImage(svc.Spec.TaskTemplate.ContainerSpec.Image, metadata(svc), svc.Spec.Labels, *c.config.WatchByDefault)
+		image, err := provider.ValidateImage(svc.Spec.TaskTemplate.ContainerSpec.Image, metadata(svc), svc.Spec.Labels, *c.config.WatchByDefault, *c.imageDefaults)
 		if err != nil {
 			c.logger.Error().Err(err).
 				Str("svc_name", svc.Spec.Name).

--- a/internal/provider/swarm/swarm.go
+++ b/internal/provider/swarm/swarm.go
@@ -10,16 +10,18 @@ import (
 // Client represents an active swarm provider object
 type Client struct {
 	*provider.Client
-	config *model.PrdSwarm
-	logger zerolog.Logger
+	config        *model.PrdSwarm
+	logger        zerolog.Logger
+	imageDefaults *model.Image
 }
 
 // New creates new swarm provider instance
-func New(config *model.PrdSwarm) *provider.Client {
+func New(config *model.PrdSwarm, imageDefaults *model.Image) *provider.Client {
 	return &provider.Client{
 		Handler: &Client{
-			config: config,
-			logger: log.With().Str("provider", "swarm").Logger(),
+			config:        config,
+			logger:        log.With().Str("provider", "swarm").Logger(),
+			imageDefaults: imageDefaults,
 		},
 	}
 }


### PR DESCRIPTION
This is a first draft attempt to allow setting default image configs at a global level.

There is one issue so far with respect to honoring defaults for the `file` provider. Right now the implemenation for every other provider is performed by passing defaults to `ValidateImage()`, however the file provider does not use this.

Since the other providers identify config by iterating through and parsing labels in `ValidateImage()`, the defaults can be checked there. The file provider instead unmarshals the image config directly into the `model.Image` struct. This poses a challenge for setting default values for booleans as we have no way to detect the difference between an absent or false value.

This could be mitigated by migrating the boolean values to pointers or by using an intermediate struct which uses pointers that the file is unmarshalled to and then coerced into the `model.Image` struct with default values set.

Open to feedback on how to solve it but I'm leaning towards the intermediate struct to avoid changing in as many places.

Fixes #491