### PR TITLE
Update binary.md

### DIFF
--- a/docs/install/binary.md
+++ b/docs/install/binary.md
@@ -24,7 +24,7 @@ Choose the archive matching the destination platform:
 And extract diun:
 
 ```shell
-wget -qO- [[ config.repo_url ]]releases/download/v[[ git.tag | trim('v') ]]/diun_[[ git.tag | trim('v') ]]_linux_amd64.tar.gz | tar -zxvf - diun
+wget -qO- [[ config.repo_url ]]/releases/download/v[[ git.tag | trim('v') ]]/diun_[[ git.tag | trim('v') ]]_linux_amd64.tar.gz | tar -zxvf - diun
 ```
 
 After getting the binary, it can be tested with [`./diun --help`](../usage/command-line.md#global-options) command


### PR DESCRIPTION
There was a missing slash in the URL in the download and extraction snippet.

Originally the result was `https://github.com/crazy-max/diunreleases/download/v4.24.0/diun_4.24.0_linux_amd64.tar.gz` but it needs to be `https://github.com/crazy-max/diun/releases/download/v4.24.0/diun_4.24.0_linux_amd64.tar.gz`
