### PR TITLE
Run slow tests in parallel to improve overall test time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN --mount=type=bind,target=. \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build <<EOT
   set -ex
-  go test -v -coverprofile=/tmp/coverage.txt -covermode=atomic -race ./...
+  go test -parallel 4 -v -coverprofile=/tmp/coverage.txt -covermode=atomic -race ./...
   go tool cover -func=/tmp/coverage.txt
 EOT
 

--- a/pkg/registry/manifest_test.go
+++ b/pkg/registry/manifest_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestCompareDigest(t *testing.T) {
+	t.Parallel()
 	rc, err := registry.New(registry.Options{
 		CompareDigest: true,
 	})
@@ -38,6 +39,7 @@ func TestCompareDigest(t *testing.T) {
 }
 
 func TestManifest(t *testing.T) {
+	t.Parallel()
 	rc, err := registry.New(registry.Options{
 		CompareDigest: true,
 		ImageOs:       "linux",
@@ -98,6 +100,7 @@ func TestManifest(t *testing.T) {
 }
 
 func TestManifestMultiUpdatedPlatform(t *testing.T) {
+	t.Parallel()
 	rc, err := registry.New(registry.Options{
 		CompareDigest: true,
 		ImageOs:       "linux",
@@ -177,6 +180,7 @@ func TestManifestMultiUpdatedPlatform(t *testing.T) {
 }
 
 func TestManifestMultiNotUpdatedPlatform(t *testing.T) {
+	t.Parallel()
 	rc, err := registry.New(registry.Options{
 		CompareDigest: true,
 		ImageOs:       "linux",
@@ -256,6 +260,7 @@ func TestManifestMultiNotUpdatedPlatform(t *testing.T) {
 }
 
 func TestManifestVariant(t *testing.T) {
+	t.Parallel()
 	rc, err := registry.New(registry.Options{
 		ImageOs:      "linux",
 		ImageArch:    "arm",

--- a/pkg/registry/tags_test.go
+++ b/pkg/registry/tags_test.go
@@ -29,43 +29,6 @@ func TestTags(t *testing.T) {
 }
 
 func TestTagsSort(t *testing.T) {
-	repotags := []string{
-		"0.1.0",
-		"0.4.0",
-		"3.0.0-beta.1",
-		"3.0.0-beta.3",
-		"3.0.0-beta.4",
-		"4",
-		"4.0.0",
-		"4.0.0-beta.1",
-		"4.1.0",
-		"4.1.1",
-		"4.10.0",
-		"4.11.0",
-		"4.12.0",
-		"4.13.0",
-		"4.14.0",
-		"4.19.0",
-		"4.2.0",
-		"4.20",
-		"4.20.0",
-		"4.20.1",
-		"4.21",
-		"4.21.0",
-		"4.3.0",
-		"4.3.1",
-		"4.4.0",
-		"4.6.1",
-		"4.7.0",
-		"4.8.0",
-		"4.8.1",
-		"4.9.0",
-		"ubuntu-5.0",
-		"alpine-5.0",
-		"edge",
-		"latest",
-	}
-
 	testCases := []struct {
 		name     string
 		sortTag  registry.SortTag
@@ -155,10 +118,10 @@ func TestTagsSort(t *testing.T) {
 			name:    "sort reverse",
 			sortTag: registry.SortTagReverse,
 			expected: []string{
-				"ubuntu-5.0",
 				"latest",
 				"edge",
 				"alpine-5.0",
+				"ubuntu-5.0",
 				"4.9.0",
 				"4.8.1",
 				"4.8.0",
@@ -235,7 +198,45 @@ func TestTagsSort(t *testing.T) {
 
 	for _, tt := range testCases {
 		tt := tt
+		repotags := []string{
+			"0.1.0",
+			"0.4.0",
+			"3.0.0-beta.1",
+			"3.0.0-beta.3",
+			"3.0.0-beta.4",
+			"4",
+			"4.0.0",
+			"4.0.0-beta.1",
+			"4.1.0",
+			"4.1.1",
+			"4.10.0",
+			"4.11.0",
+			"4.12.0",
+			"4.13.0",
+			"4.14.0",
+			"4.19.0",
+			"4.2.0",
+			"4.20",
+			"4.20.0",
+			"4.20.1",
+			"4.21",
+			"4.21.0",
+			"4.3.0",
+			"4.3.1",
+			"4.4.0",
+			"4.6.1",
+			"4.7.0",
+			"4.8.0",
+			"4.8.1",
+			"4.9.0",
+			"ubuntu-5.0",
+			"alpine-5.0",
+			"edge",
+			"latest",
+		}
+
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			tags := registry.SortTags(repotags, tt.sortTag)
 			assert.Equal(t, tt.expected, tags)
 		})


### PR DESCRIPTION
This is one mitigation for #935 and cuts test runtime in half for me.

Note regarding the change to the expected results for the reverse sort: I'm not sure exactly why it was passing before. It's possible that the slice was modified by one of the earlier tests requiring the result to be not quite the proper reversed version. This patch makes sure the slices aren't modified and also fixes the expected result.