### PR TITLE
Fix dead link in reporting-issue docs

### DIFF
--- a/docs/reporting-issue.md
+++ b/docs/reporting-issue.md
@@ -2,7 +2,7 @@
 
 ## Before submitting an issue
 
-First, [be a good guy](https://github.com/kossnocorp/etiquette/blob/master/README.md).
+First, [be a respectful](https://opensource.how/etiquette/).
 
 Please do a search in [open issues]([[ config.repo_url ]]/issues?utf8=%E2%9C%93) to see if the issue or feature request has already been filed and read the [FAQ](faq.md) page first.
 


### PR DESCRIPTION
Also makes the link text more descriptive.

Fixes #962