### PR TITLE
Add docs for image defaults

### DIFF
--- a/docs/config/watch.md
+++ b/docs/config/watch.md
@@ -13,6 +13,16 @@ watch:
   healthchecks:
     baseURL: https://hc-ping.com/
     uuid: 5bf66975-d4c7-4bf5-bcc8-b8d8a82ea278
+  imageDefaults:
+    platform:
+      os: linux
+      arch: amd64
+    regopt: ""
+    notify_on: [new, update]
+    max_tags: 10
+    sort_tags: reverse
+    include_tags: [latest]
+    exclude_tags: [dev]
 ```
 
 ## Configuration
@@ -130,3 +140,27 @@ events to [healthchecks.io](https://healthchecks.io/).
 
 * `baseURL`: Base URL for the Healthchecks Ping API (default `https://hc-ping.com/`).
 * `uuid`: UUID of an existing healthcheck (required).
+
+### `imageDefaults`
+
+ImageDefaults allows specifying default values for any configuration that is typically set at an Image level. For details More details on these examples can be seen in the [file provider documentation](docs/providers/file.md). Any value sset at the Image level will override or be merged with any deault values.
+
+!!! tip
+    Not all values must be provided. You may chose which ones you'd like to set. A an example may be to specify defaults such that new SemVer tags will be trigger notifications.
+
+!!! tip
+    Most values will be strictly overwritten by Image level variables. The notable exception is `metadata`. There are several sources of metadata that can be provided. First, via `ImageDefaults`, second via the platform, and finally by the image. When these are merged, unique keys will always persist but values will be overwritten in the order previously described. Eg. default keys will be overwritten by provider metadata keys on collision.
+
+!!! example "Config file" watching for new x.y.z semver tags
+    ```yaml
+    watch:
+      imageDefaults:
+        watch_repo: true
+        sort_tags: semver
+        include_tags:
+          - "^\d+\.\d+\.\d+$"
+
+!!! abstract "Environment variables"
+    * `DIUN_WATCH_IMAGE_DEFAULTS_WATCH_REPO`
+    * `DIUN_WATCH_IMAGE_DEFAULTS_SORT_TAGS`
+    * `DIUN_WATCH_IMAGE_DEFAULTS_INCLUDE_TAGS`

--- a/docs/config/watch.md
+++ b/docs/config/watch.md
@@ -143,7 +143,7 @@ events to [healthchecks.io](https://healthchecks.io/).
 
 ### `imageDefaults`
 
-ImageDefaults allows specifying default values for any configuration that is typically set at an Image level. For details More details on these examples can be seen in the [file provider documentation](docs/providers/file.md). Any value sset at the Image level will override or be merged with any deault values.
+ImageDefaults allows specifying default values for any configuration that is typically set at an Image level. For details More details on these examples can be seen in the [file provider documentation](../providers/file.md). Any value sset at the Image level will override or be merged with any deault values.
 
 !!! tip
     Not all values must be provided. You may chose which ones you'd like to set. A an example may be to specify defaults such that new SemVer tags will be trigger notifications.


### PR DESCRIPTION
@crazy-max I've added the documentation here. I tried to not duplicate documentation and to refer to the `file.md` doc for specifics on each field. Instead this documentation focuses on how that is used.