### PR TITLE
fix: do not set Image receiver as pointer

### DIFF
--- a/pkg/registry/image.go
+++ b/pkg/registry/image.go
@@ -19,8 +19,9 @@ type Image struct {
 	Tag     string
 	Digest  digest.Digest
 	HubLink string
-	named   reference.Named
-	opts    ParseImageOptions
+
+	named reference.Named
+	opts  ParseImageOptions
 }
 
 // ParseImageOptions holds image options for parsing.
@@ -66,17 +67,17 @@ func ParseImage(parseOpts ParseImageOptions) (Image, error) {
 }
 
 // Name returns the full name representation of an image.
-func (i *Image) Name() string {
+func (i Image) Name() string {
 	return i.named.Name()
 }
 
 // String returns the string representation of an image.
-func (i *Image) String() string {
+func (i Image) String() string {
 	return i.named.String()
 }
 
 // Reference returns either the digest if it is non-empty or the tag for the image.
-func (i *Image) Reference() string {
+func (i Image) Reference() string {
 	if len(i.Digest.String()) > 1 {
 		return i.Digest.String()
 	}
@@ -85,13 +86,13 @@ func (i *Image) Reference() string {
 }
 
 // WithDigest sets the digest for an image.
-func (i *Image) WithDigest(digest digest.Digest) (err error) {
+func (i Image) WithDigest(digest digest.Digest) (err error) {
 	i.Digest = digest
 	i.named, err = reference.WithDigest(i.named, digest)
 	return err
 }
 
-func (i *Image) hubLink() (string, error) {
+func (i Image) hubLink() (string, error) {
 	if i.opts.HubTpl != "" {
 		var out bytes.Buffer
 		tmpl, err := template.New("tmpl").


### PR DESCRIPTION
fixes #970 

We can't directly call pointer receiver methods like `Image.String()` in go `text/template`. Regression introduced by https://github.com/crazy-max/diun/pull/965/commits/bc5cdf7aa11926d6790c4cb386f9cb30e0925fa1.