### PR TITLE
Make URL and URL title configurable

### DIFF
--- a/docs/notif/pushover.md
+++ b/docs/notif/pushover.md
@@ -15,18 +15,22 @@ You can send notifications using [Pushover](https://pushover.net/).
         templateTitle: "{{ .Entry.Image }} released"
         templateBody: |
           Docker tag {{ .Entry.Image }} which you subscribed to through {{ .Entry.Provider }} provider has been released.
+        templateURLTitle: "{{ if .Entry.Image.HubLink }}{{ .Entry.Image }}{{ end }}"
+        templateURL: "{{ if .Entry.Image.HubLink }}{{ .Entry.Image.HubLink }}{{ end }}"
     ```
 
-| Name                | Default                             | Description                                                                         |
-|---------------------|-------------------------------------|-------------------------------------------------------------------------------------|
-| `token`             |                                     | Pushover [application/API token](https://pushover.net/api#registration)             |
-| `tokenFile`         |                                     | Use content of secret file as Pushover application/API token if `token` not defined |
-| `recipient`         |                                     | User key to send notification to                                                    |
-| `recipientFile`     |                                     | Use content of secret file as User key if `recipient` not defined                   |
-| `priority`          |                                     | Priority of the notification                                                        |
-| `sound`             |                                     | Notification sound to be used                                                       |
-| `templateTitle`[^1] | See [below](#default-templatetitle) | [Notification template](../faq.md#notification-template) for message title          |
-| `templateBody`[^1]  | See [below](#default-templatebody)  | [Notification template](../faq.md#notification-template) for message body           |
+| Name                   | Default                             | Description                                                                         |
+|------------------------|-------------------------------------|-------------------------------------------------------------------------------------|
+| `token`                |                                     | Pushover [application/API token](https://pushover.net/api#registration)             |
+| `tokenFile`            |                                     | Use content of secret file as Pushover application/API token if `token` not defined |
+| `recipient`            |                                     | User key to send notification to                                                    |
+| `recipientFile`        |                                     | Use content of secret file as User key if `recipient` not defined                   |
+| `priority`             |                                     | Priority of the notification                                                        |
+| `sound`                |                                     | Notification sound to be used                                                       |
+| `templateTitle`[^1]    | See [below](#default-templatetitle) | [Notification template](../faq.md#notification-template) for message title          |
+| `templateBody`[^1]     | See [below](#default-templatebody)  | [Notification template](../faq.md#notification-template) for message body           |
+| `templateURLTitle`[^1] | See [below](#default-templatetitle) | [Notification template](../faq.md#notification-template) for URL title              |
+| `templateURL`[^1]      | See [below](#default-templatebody)  | [Notification template](../faq.md#notification-template) for URL                    |
 
 !!! abstract "Environment variables"
     * `DIUN_NOTIF_PUSHOVER_TOKEN`
@@ -37,6 +41,8 @@ You can send notifications using [Pushover](https://pushover.net/).
     * `DIUN_NOTIF_PUSHOVER_SOUND`
     * `DIUN_NOTIF_PUSHOVER_TEMPLATETITLE`
     * `DIUN_NOTIF_PUSHOVER_TEMPLATEBODY`
+    * `DIUN_NOTIF_PUSHOVER_TEMPLATEURLTITLE`
+    * `DIUN_NOTIF_PUSHOVER_TEMPLATEURL`
 
 ### Default `templateTitle`
 
@@ -48,6 +54,17 @@ You can send notifications using [Pushover](https://pushover.net/).
 
 ```
 [[ config.extra.template.notif.defaultBody ]]
+```
+### Default `templateURLTitle`
+
+```
+[[ config.extra.template.notif.defaultURLTitle ]]
+```
+
+### Default `templateURL`
+
+```
+[[ config.extra.template.notif.defaultURL ]]
 ```
 
 ## Sample

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -142,10 +142,12 @@ for <code>{{ .Entry.Manifest.Platform }}</code> platform.
 						TemplateBody:  model.NotifDefaultTemplateBody,
 					},
 					Pushover: &model.NotifPushover{
-						Token:         "uQiRzpo4DXghDmr9QzzfQu27cmVRsG",
-						Recipient:     "gznej3rKEVAvPUxu9vvNnqpmZpokzF",
-						TemplateTitle: model.NotifDefaultTemplateTitle,
-						TemplateBody:  model.NotifDefaultTemplateBody,
+						Token:            "uQiRzpo4DXghDmr9QzzfQu27cmVRsG",
+						Recipient:        "gznej3rKEVAvPUxu9vvNnqpmZpokzF",
+						TemplateTitle:    model.NotifDefaultTemplateTitle,
+						TemplateBody:     model.NotifDefaultTemplateBody,
+						TemplateURLTitle: model.NotifDefaultTemplateURLTitle,
+						TemplateURL:      model.NotifDefaultTemplateURL,
 					},
 					RocketChat: &model.NotifRocketChat{
 						Endpoint:         "http://rocket.foo.com:3000",

--- a/internal/model/notif.go
+++ b/internal/model/notif.go
@@ -6,8 +6,10 @@ import (
 
 // Defaults used for notification template
 const (
-	NotifDefaultTemplateTitle = `{{ .Entry.Image }} {{ if (eq .Entry.Status "new") }}is available{{ else }}has been updated{{ end }}`
-	NotifDefaultTemplateBody  = `Docker tag {{ if .Entry.Image.HubLink }}[**{{ .Entry.Image }}**]({{ .Entry.Image.HubLink }}){{ else }}**{{ .Entry.Image }}**{{ end }} which you subscribed to through {{ .Entry.Provider }} provider {{ if (eq .Entry.Status "new") }}is available{{ else }}has been updated{{ end }} on {{ .Entry.Image.Domain }} registry (triggered by {{ .Meta.Hostname }} host).`
+	NotifDefaultTemplateTitle    = `{{ .Entry.Image }} {{ if (eq .Entry.Status "new") }}is available{{ else }}has been updated{{ end }}`
+	NotifDefaultTemplateBody     = `Docker tag {{ if .Entry.Image.HubLink }}[**{{ .Entry.Image }}**]({{ .Entry.Image.HubLink }}){{ else }}**{{ .Entry.Image }}**{{ end }} which you subscribed to through {{ .Entry.Provider }} provider {{ if (eq .Entry.Status "new") }}is available{{ else }}has been updated{{ end }} on {{ .Entry.Image.Domain }} registry (triggered by {{ .Meta.Hostname }} host).`
+	NotifDefaultTemplateURLTitle = `{{ .Meta.Name }}`
+	NotifDefaultTemplateURL      = `{{ .Meta.URL }}`
 )
 
 // NotifEntries represents a list of notification entries

--- a/internal/model/notif_pushover.go
+++ b/internal/model/notif_pushover.go
@@ -2,14 +2,16 @@ package model
 
 // NotifPushover holds Pushover notification configuration details
 type NotifPushover struct {
-	Token         string `yaml:"token,omitempty" json:"token,omitempty" validate:"omitempty"`
-	TokenFile     string `yaml:"tokenFile,omitempty" json:"tokenFile,omitempty" validate:"omitempty,file"`
-	Recipient     string `yaml:"recipient,omitempty" json:"recipient,omitempty" validate:"omitempty"`
-	RecipientFile string `yaml:"recipientFile,omitempty" json:"recipientFile,omitempty" validate:"omitempty,file"`
-	Priority      int    `yaml:"priority,omitempty" json:"priority,omitempty" validate:"omitempty,min=-2,max=2"`
-	Sound         string `yaml:"sound,omitempty" json:"sound,omitempty" validate:"omitempty"`
-	TemplateTitle string `yaml:"templateTitle,omitempty" json:"templateTitle,omitempty" validate:"required"`
-	TemplateBody  string `yaml:"templateBody,omitempty" json:"templateBody,omitempty" validate:"required"`
+	Token            string `yaml:"token,omitempty" json:"token,omitempty" validate:"omitempty"`
+	TokenFile        string `yaml:"tokenFile,omitempty" json:"tokenFile,omitempty" validate:"omitempty,file"`
+	Recipient        string `yaml:"recipient,omitempty" json:"recipient,omitempty" validate:"omitempty"`
+	RecipientFile    string `yaml:"recipientFile,omitempty" json:"recipientFile,omitempty" validate:"omitempty,file"`
+	Priority         int    `yaml:"priority,omitempty" json:"priority,omitempty" validate:"omitempty,min=-2,max=2"`
+	Sound            string `yaml:"sound,omitempty" json:"sound,omitempty" validate:"omitempty"`
+	TemplateTitle    string `yaml:"templateTitle,omitempty" json:"templateTitle,omitempty" validate:"required"`
+	TemplateBody     string `yaml:"templateBody,omitempty" json:"templateBody,omitempty" validate:"required"`
+	TemplateURL      string `yaml:"templateUrl,omitempty" json:"templateUrl,omitempty" validate:"required"`
+	TemplateURLTitle string `yaml:"templateUrlTitle,omitempty" json:"templateUrlTitle,omitempty" validate:"required"`
 }
 
 // GetDefaults gets the default values
@@ -23,4 +25,6 @@ func (s *NotifPushover) GetDefaults() *NotifPushover {
 func (s *NotifPushover) SetDefaults() {
 	s.TemplateTitle = NotifDefaultTemplateTitle
 	s.TemplateBody = NotifDefaultTemplateBody
+	s.TemplateURLTitle = NotifDefaultTemplateURLTitle
+	s.TemplateURL = NotifDefaultTemplateURL
 }

--- a/internal/notif/pushover/client.go
+++ b/internal/notif/pushover/client.go
@@ -60,13 +60,28 @@ func (c *Client) Send(entry model.NotifEntry) error {
 		return err
 	}
 
+	messageURL, err := msg.New(msg.Options{
+		Meta:          c.meta,
+		Entry:         entry,
+		TemplateTitle: c.cfg.TemplateURLTitle,
+		TemplateBody:  c.cfg.TemplateURL,
+	})
+	if err != nil {
+		return err
+	}
+
+	urlTitle, url, err := messageURL.RenderMarkdown()
+	if err != nil {
+		return err
+	}
+
 	_, err = pushover.New(token).SendMessage(&pushover.Message{
 		Title:     string(title),
 		Message:   string(body),
 		Priority:  c.cfg.Priority,
 		Sound:     c.cfg.Sound,
-		URL:       c.meta.URL,
-		URLTitle:  c.meta.Name,
+		URLTitle:  string(urlTitle),
+		URL:       string(url),
 		Timestamp: time.Now().Unix(),
 		HTML:      true,
 	}, pushover.NewRecipient(recipient))

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,10 @@ extra:
         {{ .Entry.Image }} {{ if (eq .Entry.Status "new") }}is available{{ else }}has been updated{{ end }}
       defaultBody: |
         Docker tag {{ if .Entry.Image.HubLink }}[**{{ .Entry.Image }}**]({{ .Entry.Image.HubLink }}){{ else }}**{{ .Entry.Image }}**{{ end }} which you subscribed to through {{ .Entry.Provider }} provider {{ if (eq .Entry.Status "new") }}is available{{ else }}has been updated{{ end }} on {{ .Entry.Image.Domain }} registry (triggered by {{ .Meta.Hostname }} host).
+      defaultURLTitle: |
+        {{ .Meta.Name }}
+      defaultURL: |
+        {{ .Meta.URL }}
 
 theme:
   name: material


### PR DESCRIPTION
Made URL and URL Title for Pushover configurable.
Set the default as the current behaviour (Meta.URL and Meta.Name).
Updated documentation.