### PR TITLE
Parallelize more slow running tests

### DIFF
--- a/pkg/registry/manifest_test.go
+++ b/pkg/registry/manifest_test.go
@@ -308,6 +308,7 @@ func TestManifestVariant(t *testing.T) {
 }
 
 func TestManifestTaggedDigest(t *testing.T) {
+	t.Parallel()
 	rc, err := New(Options{
 		CompareDigest: true,
 		ImageOs:       "linux",
@@ -340,6 +341,7 @@ func TestManifestTaggedDigest(t *testing.T) {
 }
 
 func TestManifestTaggedDigestUnknownTag(t *testing.T) {
+	t.Parallel()
 	rc, err := New(Options{
 		CompareDigest: true,
 		ImageOs:       "linux",

--- a/pkg/registry/tags_test.go
+++ b/pkg/registry/tags_test.go
@@ -28,6 +28,8 @@ func TestTags(t *testing.T) {
 }
 
 func TestTagsWithDigest(t *testing.T) {
+	t.Parallel()
+
 	assert.NotNil(t, rc)
 
 	image, err := ParseImage(ParseImageOptions{


### PR DESCRIPTION
Some more tests that take many seconds to run can be made parallel to speed up running. There's a linter for this if you're interested in making this required for tests.