### PR TITLE
Fix linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,12 +25,12 @@ linters:
 
 linters-settings:
   depguard:
-    list-type: blacklist
-    include-go-root: true
-    packages:
-      # The io/ioutil package has been deprecated.
-      # https://go.dev/doc/go1.16#ioutil
-      - io/ioutil
+    rules:
+      main:
+        list-mode: lax
+        deny:
+          - pkg: io/ioutil
+            desc: The io/ioutil package has been deprecated. https://go.dev/doc/go1.16#ioutil
   forbidigo:
     forbid:
       - '^fmt\.Errorf(# use errors\.Errorf instead)?$'

--- a/cmd/image.go
+++ b/cmd/image.go
@@ -31,7 +31,7 @@ type ImageListCmd struct {
 	Raw bool `kong:"name='raw',default='false',help='JSON output.'"`
 }
 
-func (s *ImageListCmd) Run(ctx *Context) error {
+func (s *ImageListCmd) Run(_ *Context) error {
 	defer s.conn.Close()
 
 	il, err := s.imageSvc.ImageList(context.Background(), &pb.ImageListRequest{})
@@ -73,7 +73,7 @@ type ImageInspectCmd struct {
 	Raw   bool   `kong:"name='raw',default='false',help='JSON output.'"`
 }
 
-func (s *ImageInspectCmd) Run(ctx *Context) error {
+func (s *ImageInspectCmd) Run(_ *Context) error {
 	defer s.conn.Close()
 
 	ii, err := s.imageSvc.ImageInspect(context.Background(), &pb.ImageInspectRequest{
@@ -111,7 +111,7 @@ type ImageRemoveCmd struct {
 	Image string `kong:"name='image',required,help='Image to remove.'"`
 }
 
-func (s *ImageRemoveCmd) Run(ctx *Context) error {
+func (s *ImageRemoveCmd) Run(_ *Context) error {
 	defer s.conn.Close()
 
 	removed, err := s.imageSvc.ImageRemove(context.Background(), &pb.ImageRemoveRequest{
@@ -147,7 +147,7 @@ const (
 	pruneAllWarning = `This will remove all manifests from the database. Are you sure you want to continue?`
 )
 
-func (s *ImagePruneCmd) Run(ctx *Context) error {
+func (s *ImagePruneCmd) Run(_ *Context) error {
 	defer s.conn.Close()
 
 	if !s.Force {

--- a/cmd/notif.go
+++ b/cmd/notif.go
@@ -17,7 +17,7 @@ type NotifTestCmd struct {
 	CliGlobals
 }
 
-func (s *NotifTestCmd) Run(ctx *Context) error {
+func (s *NotifTestCmd) Run(_ *Context) error {
 	defer s.conn.Close()
 
 	nt, err := s.notifSvc.NotifTest(context.Background(), &pb.NotifTestRequest{})

--- a/hack/lint.Dockerfile
+++ b/hack/lint.Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 ARG GO_VERSION="1.21"
-ARG GOLANGCI_LINT_VERSION="v1.51"
+ARG GOLANGCI_LINT_VERSION="v1.55"
 
 FROM golang:${GO_VERSION}-alpine AS base
 ENV GOFLAGS="-buildvcs=false"

--- a/internal/grpc/image.go
+++ b/internal/grpc/image.go
@@ -11,7 +11,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-func (c *Client) ImageList(ctx context.Context, request *pb.ImageListRequest) (*pb.ImageListResponse, error) {
+func (c *Client) ImageList(_ context.Context, _ *pb.ImageListRequest) (*pb.ImageListResponse, error) {
 	images, err := c.db.ListImage()
 	if err != nil {
 		return nil, err
@@ -46,7 +46,7 @@ func (c *Client) ImageList(ctx context.Context, request *pb.ImageListRequest) (*
 	}, nil
 }
 
-func (c *Client) ImageInspect(ctx context.Context, request *pb.ImageInspectRequest) (*pb.ImageInspectResponse, error) {
+func (c *Client) ImageInspect(_ context.Context, request *pb.ImageInspectRequest) (*pb.ImageInspectResponse, error) {
 	ref, err := reference.ParseNormalizedNamed(request.Name)
 	if err != nil {
 		return nil, err
@@ -81,7 +81,7 @@ func (c *Client) ImageInspect(ctx context.Context, request *pb.ImageInspectReque
 	}, nil
 }
 
-func (c *Client) ImageRemove(ctx context.Context, request *pb.ImageRemoveRequest) (*pb.ImageRemoveResponse, error) {
+func (c *Client) ImageRemove(_ context.Context, request *pb.ImageRemoveRequest) (*pb.ImageRemoveResponse, error) {
 	ref, err := reference.ParseNormalizedNamed(request.Name)
 	if err != nil {
 		return nil, err
@@ -125,7 +125,7 @@ func (c *Client) ImageRemove(ctx context.Context, request *pb.ImageRemoveRequest
 	}, nil
 }
 
-func (c *Client) ImagePrune(ctx context.Context, request *pb.ImagePruneRequest) (*pb.ImagePruneResponse, error) {
+func (c *Client) ImagePrune(_ context.Context, _ *pb.ImagePruneRequest) (*pb.ImagePruneResponse, error) {
 	images, err := c.db.ListImage()
 	if err != nil {
 		return nil, err

--- a/internal/grpc/notif.go
+++ b/internal/grpc/notif.go
@@ -11,7 +11,7 @@ import (
 	"github.com/crazy-max/diun/v4/pkg/registry"
 )
 
-func (c *Client) NotifTest(ctx context.Context, request *pb.NotifTestRequest) (*pb.NotifTestResponse, error) {
+func (c *Client) NotifTest(_ context.Context, _ *pb.NotifTestRequest) (*pb.NotifTestResponse, error) {
 	createdAt, _ := time.Parse("2006-01-02T15:04:05Z", "2020-03-26T12:23:56Z")
 	image, _ := registry.ParseImage(registry.ParseImageOptions{
 		Name: "diun/testnotif:latest",

--- a/internal/notif/mail/client.go
+++ b/internal/notif/mail/client.go
@@ -12,7 +12,7 @@ import (
 	"github.com/crazy-max/diun/v4/internal/notif/notifier"
 	"github.com/crazy-max/diun/v4/pkg/utl"
 	"github.com/go-gomail/gomail"
-	"github.com/matcornic/hermes/v2"
+	hermes "github.com/matcornic/hermes/v2"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 )

--- a/internal/notif/script/cmd.go
+++ b/internal/notif/script/cmd.go
@@ -7,5 +7,5 @@ import (
 	"os/exec"
 )
 
-func setSysProcAttr(cmd *exec.Cmd) {
+func setSysProcAttr(_ *exec.Cmd) {
 }


### PR DESCRIPTION
Updates golangci-lint and updates to the correct config format.

Also renames some unused parameters to `_` to appese `revive`.