### PR TITLE
feat(telegram): add support for chat topics

### DIFF
--- a/docs/notif/telegram.md
+++ b/docs/notif/telegram.md
@@ -27,7 +27,7 @@ Multiple chat IDs can be provided in order to deliver notifications to multiple 
 | `tokenFile`        |                                    | Use content of secret file as Telegram bot token if `token` not defined   |
 | `chatIDs`          |                                    | List of chat IDs to send notifications to                                 |
 | `chatIDsFile`      |                                    | Use content of secret file as chat IDs if `chatIDs` not defined           |
-| `chatTopics`       |                                    | Nested List of chat topic IDs to send notifications to.                   |
+| `chatTopics`       |                                    | List of chat topic IDs to send notifications to.                          |
 | `chatTopicsFile`   |                                    | Use content of secret file as chat topic IDs if `chatTopics` not defined  |
 | `templateBody`[^1] | See [below](#default-templatebody) | [Notification template](../faq.md#notification-template) for message body |
 
@@ -42,7 +42,7 @@ Multiple chat IDs can be provided in order to deliver notifications to multiple 
     Chat IDs secret file must be a valid JSON array like: `[123456789,987654321]`
 
 !!! example "chat topic IDS secret file"
-    Chat topics is a nested array, so you can specify multiple topics per chat ID: `[[10,15][10,20]]`
+    Chat topics is also an array, so you can specify a topic ID per chat ID: `[10,20]`
 
 ### Default `templateBody`
 

--- a/docs/notif/telegram.md
+++ b/docs/notif/telegram.md
@@ -27,6 +27,8 @@ Multiple chat IDs can be provided in order to deliver notifications to multiple 
 | `tokenFile`        |                                    | Use content of secret file as Telegram bot token if `token` not defined   |
 | `chatIDs`          |                                    | List of chat IDs to send notifications to                                 |
 | `chatIDsFile`      |                                    | Use content of secret file as chat IDs if `chatIDs` not defined           |
+| `chatTopics`       |                                    | Nested List of chat topic IDs to send notifications to.                   |
+| `chatTopicsFile`   |                                    | Use content of secret file as chat topic IDs if `chatTopics` not defined  |
 | `templateBody`[^1] | See [below](#default-templatebody) | [Notification template](../faq.md#notification-template) for message body |
 
 !!! abstract "Environment variables"
@@ -38,6 +40,9 @@ Multiple chat IDs can be provided in order to deliver notifications to multiple 
 
 !!! example "chat IDs secret file"
     Chat IDs secret file must be a valid JSON array like: `[123456789,987654321]`
+
+!!! example "chat topic IDS secret file"
+    Chat topics is a nested array, so you can specify multiple topics per chat ID: `[[10,15][10,20]]`
 
 ### Default `templateBody`
 

--- a/internal/model/notif_telegram.go
+++ b/internal/model/notif_telegram.go
@@ -5,13 +5,13 @@ const NotifTelegramDefaultTemplateBody = `Docker tag {{ if .Entry.Image.HubLink 
 
 // NotifTelegram holds Telegram notification configuration details
 type NotifTelegram struct {
-	Token          string    `yaml:"token,omitempty" json:"token,omitempty" validate:"omitempty"`
-	TokenFile      string    `yaml:"tokenFile,omitempty" json:"tokenFile,omitempty" validate:"omitempty,file"`
-	ChatIDs        []int64   `yaml:"chatIDs,omitempty" json:"chatIDs,omitempty" validate:"omitempty"`
-	ChatIDsFile    string    `yaml:"chatIDsFile,omitempty" json:"chatIDsFile,omitempty" validate:"omitempty,file"`
-	ChatTopics     [][]int64 `yaml:"chatTopics,omitempty" json:"chatTopics,omitempty" validate:"omitempty"`
-	ChatTopicsFile string    `yaml:"chatTopicsFile,omitempty" json:"chatTopicsFile,omitempty" validate:"omitempty,file"`
-	TemplateBody   string    `yaml:"templateBody,omitempty" json:"templateBody,omitempty" validate:"required"`
+	Token          string  `yaml:"token,omitempty" json:"token,omitempty" validate:"omitempty"`
+	TokenFile      string  `yaml:"tokenFile,omitempty" json:"tokenFile,omitempty" validate:"omitempty,file"`
+	ChatIDs        []int64 `yaml:"chatIDs,omitempty" json:"chatIDs,omitempty" validate:"omitempty"`
+	ChatIDsFile    string  `yaml:"chatIDsFile,omitempty" json:"chatIDsFile,omitempty" validate:"omitempty,file"`
+	ChatTopics     []int64 `yaml:"chatTopics,omitempty" json:"chatTopics,omitempty" validate:"omitempty"`
+	ChatTopicsFile string  `yaml:"chatTopicsFile,omitempty" json:"chatTopicsFile,omitempty" validate:"omitempty,file"`
+	TemplateBody   string  `yaml:"templateBody,omitempty" json:"templateBody,omitempty" validate:"required"`
 }
 
 // GetDefaults gets the default values

--- a/internal/model/notif_telegram.go
+++ b/internal/model/notif_telegram.go
@@ -5,13 +5,13 @@ const NotifTelegramDefaultTemplateBody = `Docker tag {{ if .Entry.Image.HubLink 
 
 // NotifTelegram holds Telegram notification configuration details
 type NotifTelegram struct {
-	Token          string  `yaml:"token,omitempty" json:"token,omitempty" validate:"omitempty"`
-	TokenFile      string  `yaml:"tokenFile,omitempty" json:"tokenFile,omitempty" validate:"omitempty,file"`
-	ChatIDs        []int64 `yaml:"chatIDs,omitempty" json:"chatIDs,omitempty" validate:"omitempty"`
-	ChatIDsFile    string  `yaml:"chatIDsFile,omitempty" json:"chatIDsFile,omitempty" validate:"omitempty,file"`
-	ChatTopics     []int64 `yaml:"chatTopics,omitempty" json:"chatTopics,omitempty" validate:"omitempty"`
-	ChatTopicsFile string  `yaml:"chatTopicsFile,omitempty" json:"chatTopicsFile,omitempty" validate:"omitempty,file"`
-	TemplateBody   string  `yaml:"templateBody,omitempty" json:"templateBody,omitempty" validate:"required"`
+	Token          string             `yaml:"token,omitempty" json:"token,omitempty" validate:"omitempty"`
+	TokenFile      string             `yaml:"tokenFile,omitempty" json:"tokenFile,omitempty" validate:"omitempty,file"`
+	ChatIDs        []int64            `yaml:"chatIDs,omitempty" json:"chatIDs,omitempty" validate:"omitempty"`
+	ChatIDsFile    string             `yaml:"chatIDsFile,omitempty" json:"chatIDsFile,omitempty" validate:"omitempty,file"`
+	ChatTopics     map[string][]int64 `yaml:"chatTopics,omitempty" json:"chatTopics,omitempty" validate:"omitempty"`
+	ChatTopicsFile string             `yaml:"chatTopicsFile,omitempty" json:"chatTopicsFile,omitempty" validate:"omitempty,file"`
+	TemplateBody   string             `yaml:"templateBody,omitempty" json:"templateBody,omitempty" validate:"required"`
 }
 
 // GetDefaults gets the default values

--- a/internal/model/notif_telegram.go
+++ b/internal/model/notif_telegram.go
@@ -5,11 +5,13 @@ const NotifTelegramDefaultTemplateBody = `Docker tag {{ if .Entry.Image.HubLink 
 
 // NotifTelegram holds Telegram notification configuration details
 type NotifTelegram struct {
-	Token        string  `yaml:"token,omitempty" json:"token,omitempty" validate:"omitempty"`
-	TokenFile    string  `yaml:"tokenFile,omitempty" json:"tokenFile,omitempty" validate:"omitempty,file"`
-	ChatIDs      []int64 `yaml:"chatIDs,omitempty" json:"chatIDs,omitempty" validate:"omitempty"`
-	ChatIDsFile  string  `yaml:"chatIDsFile,omitempty" json:"chatIDsFile,omitempty" validate:"omitempty,file"`
-	TemplateBody string  `yaml:"templateBody,omitempty" json:"templateBody,omitempty" validate:"required"`
+	Token          string    `yaml:"token,omitempty" json:"token,omitempty" validate:"omitempty"`
+	TokenFile      string    `yaml:"tokenFile,omitempty" json:"tokenFile,omitempty" validate:"omitempty,file"`
+	ChatIDs        []int64   `yaml:"chatIDs,omitempty" json:"chatIDs,omitempty" validate:"omitempty"`
+	ChatIDsFile    string    `yaml:"chatIDsFile,omitempty" json:"chatIDsFile,omitempty" validate:"omitempty,file"`
+	ChatTopics     [][]int64 `yaml:"chatTopics,omitempty" json:"chatTopics,omitempty" validate:"omitempty"`
+	ChatTopicsFile string    `yaml:"chatTopicsFile,omitempty" json:"chatTopicsFile,omitempty" validate:"omitempty,file"`
+	TemplateBody   string    `yaml:"templateBody,omitempty" json:"templateBody,omitempty" validate:"required"`
 }
 
 // GetDefaults gets the default values

--- a/internal/notif/telegram/client.go
+++ b/internal/notif/telegram/client.go
@@ -102,18 +102,13 @@ func (c *Client) Send(entry model.NotifEntry) error {
 	}
 
 	for i, chatID := range chatIDs {
-		if len(chatTopics) > i && len(chatTopics[i]) > 0 {
-			for _, topic := range chatTopics[i] {
-				err = sendTelegramMessage(bot, chatID, topic, string(body))
-				if err != nil {
-					return err
-				}
-			}
-		} else {
-			err = sendTelegramMessage(bot, chatID, 0, string(body))
-			if err != nil {
-				return err
-			}
+		var chatTopic int64
+		if len(chatTopics) > i {
+			chatTopic = chatTopics[i]
+		}
+		err = sendTelegramMessage(bot, chatID, chatTopic, string(body))
+		if err != nil {
+			return err
 		}
 	}
 

--- a/internal/notif/telegram/client.go
+++ b/internal/notif/telegram/client.go
@@ -2,6 +2,7 @@ package telegram
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 	"text/template"
@@ -101,14 +102,19 @@ func (c *Client) Send(entry model.NotifEntry) error {
 		return err
 	}
 
-	for i, chatID := range chatIDs {
-		var chatTopic int64
-		if len(chatTopics) > i {
-			chatTopic = chatTopics[i]
-		}
-		err = sendTelegramMessage(bot, chatID, chatTopic, string(body))
-		if err != nil {
-			return err
+	for _, chatID := range chatIDs {
+		if topics, ok := chatTopics[fmt.Sprintf("%d", chatID)]; ok {
+			for _, topic := range topics {
+				err = sendTelegramMessage(bot, chatID, topic, string(body))
+				if err != nil {
+					return err
+				}
+			}
+		} else {
+			err = sendTelegramMessage(bot, chatID, 0, string(body))
+			if err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR adds support for telegram chat topics.

`github.com/go-telegram-bot-api/telegram-bot-api` doesn't have support for topics despite several open PRs, so I switched it out with a more up-to-date library.

Diun supports sending messages to multiple chats so `ChatTopics` is a 2d slice, which allows diun to send messages to multiple chats and multiple topics.

I couldn't quite figure out how the environment variables are parsed, so I'm not 100% sure if the parsing of multi dimensional arrays works. I'll test that before I remove the draft status.

This is my first time contributing to `diun` so please let me know if I overlooked something or if have any other comments so far!

Closes #948 and #1031