### PR TITLE
Add homeassistant mqtt notifier

### DIFF
--- a/docs/notif/homeassistant.md
+++ b/docs/notif/homeassistant.md
@@ -1,0 +1,70 @@
+# MQTT notifications
+
+You can send notifications to any HomeAssistant compatible MQTT broker with the following settings.
+The notifier use the auto-discovery specs to create a new sensor per image monitored
+A message is sent on each run, even if there is no update or new image, this to allow true monitoring in HA
+
+## Configuration
+
+!!! example "File"
+    ```yaml
+    notif:
+      mqtt:
+        scheme: mqtt
+        host: localhost
+        port: 1883
+        username: guest
+        password: guest
+        client: diun
+        topic: docker/diun
+        qos: 0
+    ```
+
+| Name               | Default     | Description                                                            |
+|--------------------|-------------|------------------------------------------------------------------------|
+| `scheme`[^1]       | `mqtt`      | MQTT server scheme (`mqtt`, `mqtts`, `ws` or `wss`)                    |
+| `host`[^1]         | `localhost` | MQTT server host                                                       |
+| `port`[^1]         | `1883`      | MQTT server port                                                       |
+| `username`         |             | MQTT username                                                          |
+| `usernameFile`     |             | Use content of secret file as MQTT username if `username` not defined  |
+| `password`         |             | MQTT password                                                          |
+| `passwordFile`     |             | Use content of secret file as MQTT password if `password` not defined  |
+| `client`[^1]       |             | Client id to be used by this client when connecting to the MQTT broker |
+| `discoveryPrefix`  | `homeassistant` | Prefix for the discovery topic                                     |
+| `component`[^1]    | `sensor`    | Type of MQTT integration (e.g., `sensor`, `binary_sensor`)             |
+| `nodename`[^1]     | `diun`      | Node Name in HA (e.g, `diun`, `docker-hostname`                        |
+| `qos`              | `0`         | Ensured message delivery at specified Quality of Service (QoS)         |
+
+!!! abstract "Environment variables"
+    * `DIUN_NOTIF_HOMEASSISTANT_SCHEME`
+    * `DIUN_NOTIF_HOMEASSISTANT_HOST`
+    * `DIUN_NOTIF_HOMEASSISTANT_PORT`
+    * `DIUN_NOTIF_HOMEASSISTANT_USERNAME`
+    * `DIUN_NOTIF_HOMEASSISTANT_USERNAMEFILE`
+    * `DIUN_NOTIF_HOMEASSISTANT_PASSWORD`
+    * `DIUN_NOTIF_HOMEASSISTANT_PASSWORDFILE`
+    * `DIUN_NOTIF_HOMEASSISTANT_CLIENT`
+    * `DIUN_NOTIF_HOMEASSISTANT_DISCOVERYPREFIX`
+    * `DIUN_NOTIF_HOMEASSISTANT_COMPONENT`
+    * `DIUN_NOTIF_HOMEASSISTANT_QOS`
+
+## Sample
+
+The JSON response will look like this:
+
+```json
+{
+  "diun_version": "0.3.0",
+  "hostname": "myserver",
+  "status": "new",
+  "provider": "file",
+  "image": "docker.io/crazymax/swarm-cronjob:0.2.1",
+  "hub_link": "https://hub.docker.com/r/crazymax/swarm-cronjob",
+  "mime_type": "application/vnd.docker.distribution.manifest.v2+json",
+  "digest": "sha256:5913d4b5e8dc15430c2f47f40e43ab2ca7f2b8df5eee5db4d5c42311e08dfb79",
+  "created": "2019-01-24T10:26:49.152006005Z",
+  "platform": "linux/amd64"
+}
+```
+
+[^1]: Value required

--- a/internal/model/notif.go
+++ b/internal/model/notif.go
@@ -47,6 +47,7 @@ type Notif struct {
 	Teams      *NotifTeams      `yaml:"teams,omitempty" json:"teams,omitempty"`
 	Telegram   *NotifTelegram   `yaml:"telegram,omitempty" json:"telegram,omitempty"`
 	Webhook    *NotifWebhook    `yaml:"webhook,omitempty" json:"webhook,omitempty"`
+	HomeAssistant  *NotifHomeAssistant  `yaml:"homeassistant,omitempty" json:"homeassistant,omitempty"`
 }
 
 // GetDefaults gets the default values

--- a/internal/model/notif_homeassistant.go
+++ b/internal/model/notif_homeassistant.go
@@ -1,0 +1,34 @@
+package model
+
+type NotifHomeAssistant struct {
+    Scheme            string `yaml:"scheme,omitempty" json:"scheme,omitempty" validate:"required,oneof=mqtt mqtts ws wss"`
+    Host              string `yaml:"host,omitempty" json:"host,omitempty" validate:"required"`
+    Port              int    `yaml:"port,omitempty" json:"port,omitempty" validate:"required,min=1"`
+    Username          string `yaml:"username,omitempty" json:"username,omitempty" validate:"omitempty"`
+    UsernameFile      string `yaml:"usernameFile,omitempty" json:"usernameFile,omitempty" validate:"omitempty,file"`
+    Password          string `yaml:"password,omitempty" json:"password,omitempty" validate:"omitempty"`
+    PasswordFile      string `yaml:"passwordFile,omitempty" json:"passwordFile,omitempty" validate:"omitempty,file"`
+    Client            string `yaml:"client,omitempty" json:"client,omitempty" validate:"required"`
+    DiscoveryPrefix   string `yaml:"discoveryPrefix,omitempty" json:"discoveryPrefix,omitempty" validate:"required"`
+    Component         string `yaml:"component,omitempty" json:"component,omitempty" validate:"required"`
+    NodeName       string `yaml:"nodeName,omitempty" json:"nodeName,omitempty" validate:"omitempty"`
+    QoS               int    `yaml:"qos,omitempty" json:"qos,omitempty" validate:"omitempty"`
+}
+
+// GetDefaults gets the default values
+func (s *NotifHomeAssistant) GetDefaults() *NotifHomeAssistant {
+    n := &NotifHomeAssistant{}
+    n.SetDefaults()
+    return n
+}
+
+// SetDefaults sets the default values
+func (s *NotifHomeAssistant) SetDefaults() {
+    s.Scheme = "mqtt"
+    s.Host = "localhost"
+    s.Port = 1883
+    s.DiscoveryPrefix = "homeassistant"
+    s.Component = "sensor"
+    s.NodeName = "diun"
+    s.QoS = 0
+}

--- a/internal/notif/client.go
+++ b/internal/notif/client.go
@@ -1,110 +1,98 @@
 package notif
 
 import (
-	"strings"
+    "strings"
 
-	"github.com/crazy-max/diun/v4/internal/model"
-	"github.com/crazy-max/diun/v4/internal/notif/amqp"
-	"github.com/crazy-max/diun/v4/internal/notif/discord"
-	"github.com/crazy-max/diun/v4/internal/notif/gotify"
-	"github.com/crazy-max/diun/v4/internal/notif/mail"
-	"github.com/crazy-max/diun/v4/internal/notif/matrix"
-	"github.com/crazy-max/diun/v4/internal/notif/mqtt"
-	"github.com/crazy-max/diun/v4/internal/notif/notifier"
-	"github.com/crazy-max/diun/v4/internal/notif/ntfy"
-	"github.com/crazy-max/diun/v4/internal/notif/pushover"
-	"github.com/crazy-max/diun/v4/internal/notif/rocketchat"
-	"github.com/crazy-max/diun/v4/internal/notif/script"
-	"github.com/crazy-max/diun/v4/internal/notif/signalrest"
-	"github.com/crazy-max/diun/v4/internal/notif/slack"
-	"github.com/crazy-max/diun/v4/internal/notif/teams"
-	"github.com/crazy-max/diun/v4/internal/notif/telegram"
-	"github.com/crazy-max/diun/v4/internal/notif/webhook"
-	"github.com/rs/zerolog/log"
+    "github.com/crazy-max/diun/v4/internal/model"
+    "github.com/crazy-max/diun/v4/internal/notif/amqp"
+    "github.com/crazy-max/diun/v4/internal/notif/discord"
+    "github.com/crazy-max/diun/v4/internal/notif/gotify"
+    "github.com/crazy-max/diun/v4/internal/notif/homeassistant" // Import the new homeassistant notifier package
+    "github.com/crazy-max/diun/v4/internal/notif/mail"
+    "github.com/crazy-max/diun/v4/internal/notif/matrix"
+    "github.com/crazy-max/diun/v4/internal/notif/mqtt"
+    "github.com/crazy-max/diun/v4/internal/notif/notifier"
+    "github.com/crazy-max/diun/v4/internal/notif/ntfy"
+    "github.com/crazy-max/diun/v4/internal/notif/pushover"
+    "github.com/crazy-max/diun/v4/internal/notif/rocketchat"
+    "github.com/crazy-max/diun/v4/internal/notif/script"
+    "github.com/crazy-max/diun/v4/internal/notif/signalrest"
+    "github.com/crazy-max/diun/v4/internal/notif/slack"
+    "github.com/crazy-max/diun/v4/internal/notif/teams"
+    "github.com/crazy-max/diun/v4/internal/notif/telegram"
+    "github.com/crazy-max/diun/v4/internal/notif/webhook"
+    "github.com/rs/zerolog/log"
 )
 
 // Client represents an active webhook notification object
 type Client struct {
-	cfg       *model.Notif
-	meta      model.Meta
-	notifiers []notifier.Notifier
+    cfg       *model.Notif
+    meta      model.Meta
+    notifiers []notifier.Notifier
 }
 
 // New creates a new notification instance
 func New(config *model.Notif, meta model.Meta) (*Client, error) {
-	var c = &Client{
-		cfg:       config,
-		meta:      meta,
-		notifiers: []notifier.Notifier{},
-	}
+    var c = &Client{
+        cfg:       config,
+        meta:      meta,
+        notifiers: []notifier.Notifier{},
+    }
 
-	if config == nil {
-		log.Warn().Msg("No notifier available")
-		return c, nil
-	}
+    if config == nil {
+        log.Warn().Msg("No notifier available")
+        return c, nil
+    }
 
-	// Add notifiers
-	if config.Amqp != nil {
-		c.notifiers = append(c.notifiers, amqp.New(config.Amqp, meta))
-	}
-	if config.Discord != nil {
-		c.notifiers = append(c.notifiers, discord.New(config.Discord, meta))
-	}
-	if config.Gotify != nil {
-		c.notifiers = append(c.notifiers, gotify.New(config.Gotify, meta))
-	}
-	if config.Mail != nil {
-		c.notifiers = append(c.notifiers, mail.New(config.Mail, meta))
-	}
-	if config.Matrix != nil {
-		c.notifiers = append(c.notifiers, matrix.New(config.Matrix, meta))
-	}
-	if config.Mqtt != nil {
-		c.notifiers = append(c.notifiers, mqtt.New(config.Mqtt, meta))
-	}
-	if config.Ntfy != nil {
-		c.notifiers = append(c.notifiers, ntfy.New(config.Ntfy, meta))
-	}
-	if config.Pushover != nil {
-		c.notifiers = append(c.notifiers, pushover.New(config.Pushover, meta))
-	}
-	if config.RocketChat != nil {
-		c.notifiers = append(c.notifiers, rocketchat.New(config.RocketChat, meta))
-	}
-	if config.Script != nil {
-		c.notifiers = append(c.notifiers, script.New(config.Script, meta))
-	}
-	if config.SignalRest != nil {
-		c.notifiers = append(c.notifiers, signalrest.New(config.SignalRest, meta))
-	}
-	if config.Slack != nil {
-		c.notifiers = append(c.notifiers, slack.New(config.Slack, meta))
-	}
-	if config.Teams != nil {
-		c.notifiers = append(c.notifiers, teams.New(config.Teams, meta))
-	}
-	if config.Telegram != nil {
-		c.notifiers = append(c.notifiers, telegram.New(config.Telegram, meta))
-	}
-	if config.Webhook != nil {
-		c.notifiers = append(c.notifiers, webhook.New(config.Webhook, meta))
-	}
+    // Add notifiers
+    if config.Amqp != nil {
+        c.notifiers = append(c.notifiers, amqp.New(config.Amqp, meta))
+    }
+    if config.Discord != nil {
+        c.notifiers = append(c.notifiers, discord.New(config.Discord, meta))
+    }
+    if config.Gotify != nil {
+        c.notifiers = append(c.notifiers, gotify.New(config.Gotify, meta))
+    }
+    if config.HomeAssistant != nil { // Add the Home Assistant notifier
+        c.notifiers = append(c.notifiers, homeassistant.New(config.HomeAssistant, meta))
+    }
+    if config.Mail != nil {
+        c.notifiers = append(c.notifiers, mail.New(config.Mail, meta))
+    }
+    if config.Matrix != nil {
+        c.notifiers = append(c.notifiers, matrix.New(config.Matrix, meta))
+    }
+    if config.Mqtt != nil {
+        c.notifiers = append(c.notifiers, mqtt.New(config.Mqtt, meta))
+    }
+    if config.Ntfy != nil {
+        c.notifiers = append(c.notifiers, ntfy.New(config.Ntfy, meta))
+    }
+    if config.Pushover != nil {
+        c.notifiers = append(c.notifiers, pushover.New(config.Pushover, meta))
+    }
+    if config.RocketChat != nil {
+        c.notifiers = append(c.notifiers, rocketchat.New(config.RocketChat, meta))
+    }
+    if config.Script != nil {
+        c.notifiers = append(c.notifiers, script.New(config.Script, meta))
+    }
+    if config.SignalRest != nil {
+        c.notifiers = append(c.notifiers, signalrest.New(config.SignalRest, meta))
+    }
+    if config.Slack != nil {
+        c.notifiers = append(c.notifiers, slack.New(config.Slack, meta))
+    }
+    if config.Teams != nil {
+        c.notifiers = append(c.notifiers, teams.New(config.Teams, meta))
+    }
+    if config.Telegram != nil {
+        c.notifiers = append(c.notifiers, telegram.New(config.Telegram, meta))
+    }
+    if config.Webhook != nil {
+        c.notifiers = append(c.notifiers, webhook.New(config.Webhook, meta))
+    }
 
-	log.Debug().Msgf("%d notifier(s) created", len(c.notifiers))
-	return c, nil
-}
-
-// Send creates and sends notifications to notifiers
-func (c *Client) Send(entry model.NotifEntry) {
-	for _, n := range c.notifiers {
-		log.Debug().Str("image", entry.Image.String()).Msgf("Sending %s notification...", n.Name())
-		if err := n.Send(entry); err != nil {
-			log.Error().Err(err).Str("image", entry.Image.String()).Msgf("%s notification failed", strings.Title(n.Name()))
-		}
-	}
-}
-
-// List returns created notifiers
-func (c *Client) List() []notifier.Notifier {
-	return c.notifiers
+    return c, nil
 }

--- a/internal/notif/homeassistant/client.go
+++ b/internal/notif/homeassistant/client.go
@@ -1,0 +1,134 @@
+package mqtt
+
+import (
+    "encoding/json"
+    "fmt"
+
+    "github.com/crazy-max/diun/v4/internal/model"
+    "github.com/crazy-max/diun/v4/internal/notif/notifier"
+    "github.com/crazy-max/diun/v4/pkg/utl"
+    MQTT "github.com/eclipse/paho.mqtt.golang"
+)
+
+// Client represents an active mqtt notification object
+type Client struct {
+    *notifier.Notifier
+    cfg        *model.NotifHomeAssistant
+    meta       model.Meta
+    mqttClient MQTT.Client
+}
+
+// New creates a new mqtt notification instance
+func New(config *model.NotifHomeAssistant, meta model.Meta) notifier.Notifier {
+    return notifier.Notifier{
+        Handler: &Client{
+            cfg:  config,
+            meta: meta,
+        },
+    }
+}
+
+// Name returns notifier's name
+func (c *Client) Name() string {
+    return "mqtt"
+}
+
+// Send creates and sends a mqtt notification with an entry
+func (c *Client) Send(entry model.NotifEntry) error {
+    username, err := utl.GetSecret(c.cfg.Username, c.cfg.UsernameFile)
+    if (err != nil) {
+        return err
+    }
+
+    password, err := utl.GetSecret(c.cfg.Password, c.cfg.PasswordFile)
+    if (err != nil) {
+        return err
+    }
+
+    broker := fmt.Sprintf("%s://%s:%d", c.cfg.Scheme, c.cfg.Host, c.cfg.Port)
+    opts := MQTT.NewClientOptions().AddBroker(broker).SetClientID(c.cfg.Client)
+    opts.Username = username
+    opts.Password = password
+
+    if c.mqttClient == nil {
+        c.mqttClient = MQTT.NewClient(opts)
+        if token := c.mqttClient.Connect(); token.Wait() && token.Error() != nil {
+            return token.Error()
+        }
+    }
+
+	// Extract the repository name (without version) and sanitize it
+	repoName := strings.Split(entry.Image, ":")[0]
+    sanitizedImage := strings.ReplaceAll(repoName, "/", "_")
+
+    // Define the discovery topic
+    discoveryTopic := fmt.Sprintf("%s/%s/%s/%s/config", c.cfg.DiscoveryPrefix, c.cfg.Component, c.cfg.NodeName, sanitizedImage)
+
+    // Create the discovery payload
+    discoveryPayload := map[string]interface{}{
+        "name":        sanitizedImage,
+        "unique_id":   sanitizedImage,
+        "state_topic": fmt.Sprintf("%s/%s/%s/%s/config", c.cfg.DiscoveryPrefix, c.cfg.Component, c.cfg.NodeName, sanitizedImage),
+        "json_attributes_topic": fmt.Sprintf("%s/%s/%s/%s/config", c.cfg.DiscoveryPrefix, c.cfg.Component, c.cfg.NodeName, sanitizedImage),
+        "availability_topic":    "homeassistant/status",
+        "device": map[string]interface{}{
+            "identifiers":  sanitizedImage,
+            "name":         sanitizedImage,
+            "sw_version":   "1.0",
+            "model":        "MQTT Sensor",
+            "manufacturer": "Diun Image Update Notifier",
+        },
+    }
+
+    payloadBytes, err := json.Marshal(discoveryPayload)
+    if err != nil {
+        return err
+    }
+
+    // Publish the discovery message
+    token := c.mqttClient.Publish(discoveryTopic, byte(c.cfg.QoS), true, payloadBytes)
+    token.Wait()
+    if token.Error() != nil {
+        return token.Error()
+    }
+
+	// Prepare the state payload
+	var statePayload map[string]interface{}
+	if entry.Status == "new" {
+		statePayload = map[string]interface{}{
+			"state":           "New Image",
+			"current_version": entry.Image,
+			"new_version":     "",
+			"icon":            "mdi:package-variant",
+		}
+	} else if entry.Status == "update" {
+		statePayload = map[string]interface{}{
+			"state":           "Update Available",
+			"current_version": entry.Image,
+			"new_version":     entry.Image,
+			"icon":            "mdi:package-up",
+		}
+	} else {
+		statePayload = map[string]interface{}{
+			"state":           "No Update",
+			"current_version": entry.Image,
+			"new_version":     "",
+			"icon":            "mdi:package-variant-closed",
+		}
+	}
+
+    statePayloadBytes, err := json.Marshal(statePayload)
+    if err != nil {
+        return err
+    }
+
+    // Publish the state message
+    stateTopic := fmt.Sprintf("%s/%s/%s/%s/config", c.cfg.DiscoveryPrefix, c.cfg.Component, c.cfg.NodeName, sanitizedImage)
+    token = c.mqttClient.Publish(stateTopic, byte(c.cfg.QoS), false, statePayloadBytes)
+    token.Wait()
+    if token.Error() != nil {
+        return token.Error()
+    }
+
+    return nil
+}


### PR DESCRIPTION
Add homeassistant mqtt compatible notifier

- Add a notifier to publish mqtt message to 
home assistant mqtt compatible broker (e.g.
 mosquitto)
- Use homeassistant mqtt discovery message 
to create a new sensor per image name (per
 container)
- Create a new model dedicated to 
homeassistant notifier
- Update docs to add home assistant notifier
