### PR TITLE
Update faq.md to note that notifications only happen on schedule and not on first run/deploy

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -25,6 +25,9 @@ Or within a container:
 ```shell
 docker compose exec diun diun notif test
 ```
+!!! warning
+    `While the test notification might work, it's important to note that Diun will only notify when the cronjob triggers and not on the first run`
+
 
 ## Customize the hostname
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -26,7 +26,7 @@ Or within a container:
 docker compose exec diun diun notif test
 ```
 !!! warning
-    `While the test notification might work, it's important to note that Diun will only notify when the cronjob triggers and not on the first run`
+    `While the test notification might work, it's important to note that, by defaul, Diun will only notify when the cronjob triggers and not on the first run. Check [.watch](config/watch.md) for firstCheckNotif`
 
 
 ## Customize the hostname

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -26,7 +26,7 @@ Or within a container:
 docker compose exec diun diun notif test
 ```
 
-While the test notification might work, it's important to note that, by default, Diun will only notify when the cronjob triggers and not on the first run. Check [.watch](config/watch.md) for ´firstCheckNotif´
+While the test notification might work, it's important to note that, by default, Diun will only notify when the cronjob triggers and not on the first run. Check [.watch](config/watch.md) for `firstCheckNotif`.
 
 
 ## Customize the hostname

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -25,8 +25,8 @@ Or within a container:
 ```shell
 docker compose exec diun diun notif test
 ```
-!!! warning
-    `While the test notification might work, it's important to note that, by defaul, Diun will only notify when the cronjob triggers and not on the first run. Check [.watch](config/watch.md) for firstCheckNotif`
+
+While the test notification might work, it's important to note that, by default, Diun will only notify when the cronjob triggers and not on the first run. Check [.watch](config/watch.md) for ´firstCheckNotif´
 
 
 ## Customize the hostname


### PR DESCRIPTION
Add note mentioning that the notification won't be sent when deploying (first run), only when scheduled.