### PR TITLE
Trim new line at the end of secret files

### DIFF
--- a/pkg/utl/utl.go
+++ b/pkg/utl/utl.go
@@ -3,6 +3,7 @@ package utl
 import (
 	"os"
 	"regexp"
+	"strings"
 	"time"
 )
 
@@ -62,7 +63,7 @@ func GetSecret(plaintext, filename string) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		return string(b), nil
+		return strings.TrimRight(string(b), "\n"), nil
 	}
 	return "", nil
 }


### PR DESCRIPTION
fixes #1038

As explained in issue #1038, the new line at the end of a file is considered part of the secret. This leads to errors if that file is created via a normal text editor that appends a new line at the end of the file. For example, nano.

I've also encountered this issue with the telegram token file and got the error `url: invalid control character in URL`.

This PR solves this by trimming the new line at the end of the string loaded from the secret file, it does it in the same way as authelia does: https://github.com/authelia/authelia/blob/c8033745027f8257fb775674ef5b4595c9daec79/internal/configuration/helpers.go#L118