### PR TITLE
remove embed rending if renderFields config option disabled

### DIFF
--- a/docs/notif/discord.md
+++ b/docs/notif/discord.md
@@ -22,11 +22,11 @@ Allow sending notifications to your Discord channel.
     ```
 
 | Name               | Default                            | Description                                                                                               |
-|--------------------|------------------------------------|-----------------------------------------------------------------------------------------------------------|
+| ------------------ | ---------------------------------- | --------------------------------------------------------------------------------------------------------- |
 | `webhookURL`       |                                    | Discord [incoming webhook URL](https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks) |
 | `webhookURLFile`   |                                    | Use content of secret file as webhook URL if `webhookURL` is not defined                                  |
 | `mentions`         |                                    | List of users or roles to notify                                                                          |
-| `renderFields`     | `true`                             | Render [field objects](https://discordjs.guide/popular-topics/embeds.html)                                |
+| `renderFields`     | `true`                             | Render embed and [field objects](https://discordjs.guide/popular-topics/embeds.html)                      |
 | `timeout`          | `10s`                              | Timeout specifies a time limit for the request to be made                                                 |
 | `templateBody`[^1] | See [below](#default-templatebody) | [Notification template](../faq.md#notification-template) for message body                                 |
 

--- a/internal/notif/discord/client.go
+++ b/internal/notif/discord/client.go
@@ -69,9 +69,9 @@ func (c *Client) Send(entry model.NotifEntry) error {
 	}
 	content.WriteString(string(body))
 
-	var fields []EmbedField
+	var embeds []Embed
 	if *c.cfg.RenderFields {
-		fields = []EmbedField{
+		fields := []EmbedField{
 			{
 				Name:  "Hostname",
 				Value: c.meta.Hostname,
@@ -99,14 +99,7 @@ func (c *Client) Send(entry model.NotifEntry) error {
 				Value: entry.Image.HubLink,
 			})
 		}
-	}
-
-	dataBuf := new(bytes.Buffer)
-	if err := json.NewEncoder(dataBuf).Encode(Message{
-		Content:   content.String(),
-		Username:  c.meta.Name,
-		AvatarURL: c.meta.Logo,
-		Embeds: []Embed{
+		embeds = []Embed{
 			{
 				Author: EmbedAuthor{
 					Name:    c.meta.Name,
@@ -118,7 +111,15 @@ func (c *Client) Send(entry model.NotifEntry) error {
 					Text: fmt.Sprintf("%s © %d %s %s", c.meta.Author, time.Now().Year(), c.meta.Name, c.meta.Version),
 				},
 			},
-		},
+		}
+	}
+
+	dataBuf := new(bytes.Buffer)
+	if err := json.NewEncoder(dataBuf).Encode(Message{
+		Content:   content.String(),
+		Username:  c.meta.Name,
+		AvatarURL: c.meta.Logo,
+		Embeds:    embeds,
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
resolves #614

With this change, if renderFields option for discord notifications is disabled, no embed or fields are shown.

Previous behaviour with the renderFields option disabled included an embed with no fields inside, which served no purpose except branding.

Documentation has been appropriately updated to indicate that the embed rendering depends upon this option, as well as fields.