### PR TITLE
Update INCLUDE/EXCLUDETAGS docs

### DIFF
--- a/docs/config/defaults.md
+++ b/docs/config/defaults.md
@@ -100,6 +100,9 @@ enabled.
     ```
 
 !!! abstract "Environment variables"
+
+Comma separated list of regular expressions to include tags.
+
     * `DIUN_DEFAULTS_INCLUDETAGS=^\d+\.\d+\.\d+$`
 
 ### `excludeTags`
@@ -115,6 +118,9 @@ enabled.
     ```
 
 !!! abstract "Environment variables"
+
+Comma separated list of regular expressions to include tags.
+
     * `DIUN_DEFAULTS_EXCLUDETAGS=dev`
 
 ### `metadata`


### PR DESCRIPTION
Now mentions that these are comma separated lists, so expressions that include commas cannot be used