### PR TITLE
Skip manifest pull if ignoring image updates

### DIFF
--- a/internal/model/image.go
+++ b/internal/model/image.go
@@ -1,6 +1,8 @@
 package model
 
 import (
+	"slices"
+
 	"github.com/crazy-max/diun/v4/pkg/registry"
 )
 
@@ -60,11 +62,6 @@ func (ns *NotifyOn) Valid() bool {
 }
 
 // OneOf checks if notify status is one of the values in the list
-func (ns *NotifyOn) OneOf(nsl []NotifyOn) bool {
-	for _, n := range nsl {
-		if n == *ns {
-			return true
-		}
-	}
-	return false
+func (ns NotifyOn) OneOf(nsl []NotifyOn) bool {
+	return slices.Contains(nsl, ns)
 }


### PR DESCRIPTION
Pulling manifests for every tag is the main reason for significant API usage. If the user only cares about new images and not tag updates, then this is unnecessary and can be skipped.

I'm not sure if this is testable with the current setup, but if I need to get additional coverage I can probably throw something in anyway.