### PR TITLE
Add semver option to watch_repo

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -203,7 +203,7 @@ regopts:
 Or you can tweak the [`schedule` setting](config/watch.md#schedule) with something like `0 */6 * * *` (every 6 hours).
 
 !!! warning
-    Also be careful with the `watch_repo` setting as it will fetch manifest for **ALL** tags available for the image.
+    Also be careful with the `watch_repo` setting as it will fetch manifest for **ALL** tags available for the image if set to true. If using semver sorting, you can set `watch_repo` to semver and it will instead only watch images that are newer versions than the current image.
 
 ## Tags sorting when using `watch_repo`
 

--- a/internal/app/job.go
+++ b/internal/app/job.go
@@ -63,7 +63,7 @@ func (di *Diun) createJob(job model.Job) {
 	// Set defaults
 	if err := mergo.Merge(&job.Image, model.Image{
 		Platform:  model.ImagePlatform{},
-		WatchRepo: utl.NewFalse(),
+		WatchRepo: model.WatchRepoNo,
 		MaxTags:   0,
 	}); err != nil {
 		sublog.Error().Err(err).Msg("Cannot set default values")
@@ -118,7 +118,7 @@ func (di *Diun) createJob(job model.Job) {
 		sublog.Error().Err(err).Msgf("Invoking job")
 	}
 
-	if !*job.Image.WatchRepo || len(job.RegImage.Domain) == 0 {
+	if job.Image.WatchRepo == model.WatchRepoNo || len(job.RegImage.Domain) == 0 {
 		return
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -60,7 +60,7 @@ func TestLoadFile(t *testing.T) {
 					},
 				},
 				Defaults: &model.Defaults{
-					WatchRepo: utl.NewFalse(),
+					WatchRepo: model.WatchRepoNo,
 					NotifyOn:  []model.NotifyOn{model.NotifyOnNew},
 					MaxTags:   5,
 					SortTags:  registry.SortTagReverse,

--- a/internal/model/defaults.go
+++ b/internal/model/defaults.go
@@ -2,12 +2,11 @@ package model
 
 import (
 	"github.com/crazy-max/diun/v4/pkg/registry"
-	"github.com/crazy-max/diun/v4/pkg/utl"
 )
 
 // Defaults holds data necessary for image defaults configuration
 type Defaults struct {
-	WatchRepo   *bool             `yaml:"watchRepo,omitempty" json:"watchRepo,omitempty"`
+	WatchRepo   WatchRepo         `yaml:"watchRepo,omitempty" json:"watchRepo,omitempty"`
 	NotifyOn    []NotifyOn        `yaml:"notifyOn,omitempty" json:"notifyOn,omitempty"`
 	MaxTags     int               `yaml:"maxTags,omitempty" json:"maxTags,omitempty"`
 	SortTags    registry.SortTag  `yaml:"sortTags,omitempty" json:"sortTags,omitempty"`
@@ -25,7 +24,7 @@ func (s *Defaults) GetDefaults() *Defaults {
 
 // SetDefaults sets the default values
 func (s *Defaults) SetDefaults() {
-	s.WatchRepo = utl.NewFalse()
+	s.WatchRepo = WatchRepoNo
 	s.NotifyOn = NotifyOnDefaults
 	s.SortTags = registry.SortTagReverse
 }

--- a/internal/model/image.go
+++ b/internal/model/image.go
@@ -1,6 +1,8 @@
 package model
 
 import (
+	"slices"
+
 	"github.com/crazy-max/diun/v4/pkg/registry"
 )
 
@@ -9,7 +11,7 @@ type Image struct {
 	Name        string            `yaml:"name,omitempty" json:",omitempty"`
 	Platform    ImagePlatform     `yaml:"platform,omitempty" json:",omitempty"`
 	RegOpt      string            `yaml:"regopt,omitempty" json:",omitempty"`
-	WatchRepo   *bool             `yaml:"watch_repo,omitempty" json:",omitempty"`
+	WatchRepo   WatchRepo         `yaml:"watch_repo,omitempty" json:",omitempty"`
 	NotifyOn    []NotifyOn        `yaml:"notify_on,omitempty" json:",omitempty"`
 	MaxTags     int               `yaml:"max_tags,omitempty" json:",omitempty"`
 	SortTags    registry.SortTag  `yaml:"sort_tags,omitempty" json:",omitempty"`
@@ -26,6 +28,25 @@ type ImagePlatform struct {
 	Arch    string `yaml:"arch,omitempty" json:",omitempty"`
 	Variant string `yaml:"variant,omitempty" json:",omitempty"`
 }
+
+// WatchRepo constants
+const (
+	WatchRepoNo     = WatchRepo("false")
+	WatchRepoAll    = WatchRepo("true")
+	WatchRepoSemver = WatchRepo("semver")
+)
+
+// Valid checks watch repo is valid
+func (w WatchRepo) Valid() bool {
+	return slices.Contains([]WatchRepo{
+		WatchRepoNo,
+		WatchRepoAll,
+		WatchRepoSemver,
+	}, w)
+}
+
+// WatchRepo holds repo watching intent
+type WatchRepo string
 
 // ImageStatus constants
 const (

--- a/internal/provider/common.go
+++ b/internal/provider/common.go
@@ -51,9 +51,14 @@ func ValidateImage(image string, metadata, labels map[string]string, watchByDef 
 			img.RegOpt = value
 		case key == "diun.watch_repo":
 			if watchRepo, err := strconv.ParseBool(value); err == nil {
-				img.WatchRepo = &watchRepo
+				// If boolean value, coerce it into true/false
+				img.WatchRepo = model.WatchRepo(strconv.FormatBool(watchRepo))
 			} else {
-				return img, errors.Wrapf(err, "cannot parse %q value of label %s", value, key)
+				// Otherwise use it directly
+				img.WatchRepo = model.WatchRepo(value)
+			}
+			if !img.WatchRepo.Valid() {
+				return img, errors.Errorf(`invalid value of watch_repo %q`, value)
 			}
 		case key == "diun.notify_on":
 			if len(value) == 0 {

--- a/internal/provider/common_test.go
+++ b/internal/provider/common_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/crazy-max/diun/v4/internal/model"
 	"github.com/crazy-max/diun/v4/pkg/registry"
-	"github.com/crazy-max/diun/v4/pkg/utl"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
@@ -111,11 +110,11 @@ func TestValidateImage(t *testing.T) {
 			image:      "myimg",
 			watchByDef: true,
 			defaults: &model.Defaults{
-				WatchRepo: utl.NewTrue(),
+				WatchRepo: model.WatchRepoAll,
 			},
 			expectedImage: model.Image{
 				Name:      "myimg",
-				WatchRepo: utl.NewTrue(),
+				WatchRepo: model.WatchRepoAll,
 			},
 			expectedErr: nil,
 		},
@@ -130,7 +129,7 @@ func TestValidateImage(t *testing.T) {
 			expectedImage: model.Image{
 				Name: "myimg",
 			},
-			expectedErr: errors.New(`cannot parse "chickens" value of label diun.watch_repo`),
+			expectedErr: errors.New(`invalid value of watch_repo "chickens"`),
 		},
 		{
 			name:       "Override default image values with labels (true > false)",
@@ -140,27 +139,43 @@ func TestValidateImage(t *testing.T) {
 				"diun.watch_repo": "false",
 			},
 			defaults: &model.Defaults{
-				WatchRepo: utl.NewTrue(),
+				WatchRepo: model.WatchRepoAll,
 			},
 			expectedImage: model.Image{
 				Name:      "myimg",
-				WatchRepo: utl.NewFalse(),
+				WatchRepo: model.WatchRepoNo,
 			},
 			expectedErr: nil,
 		},
 		{
-			name:       "Override default image values with labels (false > true): invalid label error",
+			name:       "Override default image values with labels (false > true)",
 			image:      "myimg",
 			watchByDef: true,
 			labels: map[string]string{
 				"diun.watch_repo": "true",
 			},
 			defaults: &model.Defaults{
-				WatchRepo: utl.NewFalse(),
+				WatchRepo: model.WatchRepoNo,
 			},
 			expectedImage: model.Image{
 				Name:      "myimg",
-				WatchRepo: utl.NewTrue(),
+				WatchRepo: model.WatchRepoAll,
+			},
+			expectedErr: nil,
+		},
+		{
+			name:       "Override default image values with labels (false > semver)",
+			image:      "myimg",
+			watchByDef: true,
+			labels: map[string]string{
+				"diun.watch_repo": "semver",
+			},
+			defaults: &model.Defaults{
+				WatchRepo: model.WatchRepoNo,
+			},
+			expectedImage: model.Image{
+				Name:      "myimg",
+				WatchRepo: model.WatchRepoSemver,
 			},
 			expectedErr: nil,
 		},

--- a/internal/provider/file/file_test.go
+++ b/internal/provider/file/file_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/crazy-max/diun/v4/internal/model"
 	"github.com/crazy-max/diun/v4/pkg/registry"
-	"github.com/crazy-max/diun/v4/pkg/utl"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -42,7 +41,7 @@ var (
 			Provider: "file",
 			Image: model.Image{
 				Name:      "docker.bintray.io/jfrog/xray-server:2.8.6",
-				WatchRepo: utl.NewTrue(),
+				WatchRepo: model.WatchRepoAll,
 				NotifyOn: []model.NotifyOn{
 					model.NotifyOnNew,
 				},
@@ -78,7 +77,7 @@ var (
 			Provider: "file",
 			Image: model.Image{
 				Name:      "crazymax/swarm-cronjob",
-				WatchRepo: utl.NewTrue(),
+				WatchRepo: model.WatchRepoAll,
 				NotifyOn:  model.NotifyOnDefaults,
 				SortTags:  registry.SortTagSemver,
 				MaxTags:   25,
@@ -94,7 +93,7 @@ var (
 			Provider: "file",
 			Image: model.Image{
 				Name:      "docker.io/portainer/portainer",
-				WatchRepo: utl.NewTrue(),
+				WatchRepo: model.WatchRepoAll,
 				NotifyOn:  model.NotifyOnDefaults,
 				MaxTags:   10,
 				SortTags:  registry.SortTagReverse,
@@ -110,7 +109,7 @@ var (
 			Provider: "file",
 			Image: model.Image{
 				Name:      "traefik",
-				WatchRepo: utl.NewTrue(),
+				WatchRepo: model.WatchRepoAll,
 				NotifyOn:  model.NotifyOnDefaults,
 				SortTags:  registry.SortTagDefault,
 				MaxTags:   25,
@@ -176,7 +175,7 @@ var (
 			Provider: "file",
 			Image: model.Image{
 				Name:      "crazymax/ddns-route53",
-				WatchRepo: utl.NewTrue(),
+				WatchRepo: model.WatchRepoAll,
 				NotifyOn:  model.NotifyOnDefaults,
 				SortTags:  registry.SortTagReverse,
 				MaxTags:   25,
@@ -261,10 +260,10 @@ func TestDefaultImageOptions(t *testing.T) {
 	fc := New(&model.PrdFile{
 		Filename: "./fixtures/dockerhub.yml",
 	}, &model.Defaults{
-		WatchRepo: utl.NewTrue(),
+		WatchRepo: model.WatchRepoAll,
 	})
 
 	for _, job := range fc.ListJob() {
-		assert.True(t, *job.Image.WatchRepo)
+		assert.Equal(t, model.WatchRepoAll, job.Image.WatchRepo)
 	}
 }

--- a/internal/provider/file/image.go
+++ b/internal/provider/file/image.go
@@ -33,7 +33,7 @@ func (c *Client) listFileImage() []model.Image {
 
 		for _, item := range items {
 			// Set default WatchRepo
-			if item.WatchRepo == nil {
+			if item.WatchRepo == "" {
 				item.WatchRepo = c.defaults.WatchRepo
 			}
 			// Check NotifyOn


### PR DESCRIPTION
This will fetch the list of all tags from the repo, but exclude any that are a lower semver than the current tag. This also requires sort_tags to be semver as well.

Use case for this is when a user always pins to a semver tag, eg `2.1.0`. In that case, they need to watch for tags with a newer semver only. A new `2.1.1` tag should notify the user, however a patch release to an older `1.9.1` tag should not.

Something I'm thinking about is how to handle this being set to `semver` but sorting not. Log and ignore, update default value, throw error if explicitly in conflict?