### PR TITLE
chore: redadct url param secrets in logs

### DIFF
--- a/internal/notif/client.go
+++ b/internal/notif/client.go
@@ -119,7 +119,7 @@ func SanitizeUrlTokens(err error) string {
 		return ""
 	}
 	params := []string{"token", "apikey", "api_key", "access_token", "auth", "authorization", "jwt", "sessionid", "session_id", "password", "secret", "key", "code"}
-	pattern := `([?&](` + strings.Join(params, "|") + `)=)[^&"\s]+` // scan ? or & followed by param name and =, then redact until & or space or " (end of URL)
+	pattern := `([?&](` + strings.Join(params, "|") + `)=)[^&"\s]+` // scan ? or & followed by one of the param names and =, then redact until &, whitespace, or " (end of URL)
 	re := regexp.MustCompile(pattern)
 	return re.ReplaceAllString(err.Error(), `$1[REDACTED]`) // leave param name, redact secret value
 }

--- a/internal/notif/client_test.go
+++ b/internal/notif/client_test.go
@@ -1,0 +1,45 @@
+package notif
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestSanitizeUrlTokens(t *testing.T) {
+	tests := []struct {
+		input    error
+		expected string
+	}{
+		{
+			input:    errors.New(`Post "http://gotify:9265/message?token=supersecret": dial tcp ...`),
+			expected: `Post "http://gotify:9265/message?token=[REDACTED]": dial tcp ...`,
+		},
+		{
+			input:    errors.New(`GET /api?apikey=12345&auth=abcdef`),
+			expected: `GET /api?apikey=[REDACTED]&auth=[REDACTED]`,
+		},
+		{
+			input:    errors.New(`https://foo.com?token=abc&apikey=def&password=ghi`),
+			expected: `https://foo.com?token=[REDACTED]&apikey=[REDACTED]&password=[REDACTED]`,
+		},
+		{
+			input:    errors.New(`https://bar.com?sessionid=xyz&key=123`),
+			expected: `https://bar.com?sessionid=[REDACTED]&key=[REDACTED]`,
+		},
+		{
+			input:    errors.New(`No sensitive params here`),
+			expected: `No sensitive params here`,
+		},
+		{
+			input:    errors.New(`Post "http://gotify:9265/message?otherparam=asdf": dial tcp ...`),
+			expected: `Post "http://gotify:9265/message?otherparam=asdf": dial tcp ...`,
+		},
+	}
+
+	for _, tt := range tests {
+		result := SanitizeUrlTokens(tt.input)
+		if result != tt.expected {
+			t.Errorf("SanitizeUrlTokens(%q) = %q; want %q", tt.input.Error(), result, tt.expected)
+		}
+	}
+}


### PR DESCRIPTION
Got this error message when trying to set up diun with Gotify, with the auth token in plaintext, which can be insecure (CWE-117 / CWE-532).

`Sat, 11 Oct 2025 12:00:04 PDT ERR Gotify notification failed error="Post \"http://gotify:9265/message?token=xxx\": dial tcp 172.20.0.3:9265: connect: connection refused" image=docker.io/searxng/searxng:latest`

This PR adds sanitization for logged URLs/paths (based on common param names for secrets) while logging and adds tests.