### PR TITLE
Trim whitespaces, spaces, tabs from secret file content

### DIFF
--- a/pkg/utl/utl.go
+++ b/pkg/utl/utl.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"regexp"
 	"time"
+	"strings"
 )
 
 // MatchString reports whether a string s
@@ -62,7 +63,8 @@ func GetSecret(plaintext, filename string) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		return string(b), nil
+		// trim newlines, spaces and tabs. Solves #665
+		return strings.TrimSpace(string(b)), nil
 	}
 	return "", nil
 }


### PR DESCRIPTION
Trim newlines, spaces, and tabs from file content to address recurring issues such as  #665 , #1358, #1531 etc