### PR TITLE
fix(notif/matrix): store credentials after login to fix M_MISSING_TOKEN

### DIFF
--- a/internal/notif/matrix/client.go
+++ b/internal/notif/matrix/client.go
@@ -66,6 +66,7 @@ func (c *Client) Send(entry model.NotifEntry) error {
 		},
 		Password:                 password,
 		InitialDeviceDisplayName: c.meta.Name,
+		StoreCredentials:         true,
 	})
 	if err != nil {
 		return errors.Wrap(err, "failed to authenticate Matrix user")


### PR DESCRIPTION
## Description

Fixes issues introduced by #1529's migration from gomatrix to mautrix-go.

## Problem

Matrix notifications fail immediately after login with:

```
M_MISSING_TOKEN (HTTP 401): M_MISSING_TOKEN: Missing access token.
```

## Root Cause

The migration from `gomatrix` to `mautrix-go` in #1529 missed a critical API difference regarding token persistence.

`gomatrix`: Required an explicit call to `SetCredentials()` after login to attach the token to the client instance.  
`mautrix-go`: `SetCredentials()` is deprecated. Instead, the `mautrix.ReqLogin` struct requires `StoreCredentials: true` to automatically persist the token to the client context upon successful login (see [mautrix-go docs](https://pkg.go.dev/maunium.net/go/mautrix#ReqLogin)).

The migration correctly removed the deprecated SetCredentials() call but did not add its replacement: the StoreCredentials: true flag in the login request. Consequently, while the HTTP `POST /login` succeeds, the returned access token is discarded. The client instance remains unauthenticated for all subsequent steps (`JoinRoom`, `SendMessageEvent`, `Logout`), causing the `M_MISSING_TOKEN` error.

## Bug Reproduction

I was unable to reproduce the "working on Conduit" claim from #1529. Testing was performed with:

- `diun:edge` (`v4.30.0-27-gcfc7fdb6`)
- `matrixconduit/matrix-conduit:latest` (which currently corresponds to v0.10.9)
- Standard Docker Compose deployments for both
- `diun notif test` command

```
docker exec diun-diun-1 diun --version
v4.30.0-27-gcfc7fdb6

docker exec diun-diun-1 diun notif test
diun: error: rpc error: code = Unknown desc = failed to join room: M_MISSING_TOKEN (HTTP 401): M_MISSING_TOKEN: Missing access token.
```

The issue was reproducible 100% of the time on the current `edge` build. The login succeeded (as evidenced by lingering diun clients in the user's device list, but anything beyond that fails. This behavior is deterministic: without the `StoreCredentials` flag, the token is never stored in the client struct, so all authenticated API calls _must_ fail. It is unclear to me how the implementation in #1529 passed verification, as the logic prevents the client from persisting the session token required for subsequent requests. There is no environment variable or server configuration that bypasses this client-side requirement.

## Fix

Add `StoreCredentials: true` to the `mautrix.ReqLogin` struct. The notifications now work as expected.

```
docker exec diun-diun-1 diun --version
392e5223

docker exec diun-diun-1 diun notif test
Notification sent for matrix notifier(s)
```

Testing was performed on `matrixconduit/matrix-conduit:latest` (v0.10.9). 

## Checks

- [x] `docker buildx bake validate` passed
- [x] `docker buildx bake test` passed
- [ ] `docker buildx bake artifact-all image-all` (Failed due to local driver limitations, unrelated to code changes)

## Note

This PR fixes the immediate breakage. 
While investigating why my notifications weren't working, I've noticed that the current approach - performing a full authentication handshake and room join (even if the user is already in the room), and logout for every single notification - is architecturally expensive and atypical for notification integrations. It also risks running into rate limits. A cleaner implementation would use a pre-configured access token (similar to how Telegram, Gotify, and ntfy already work) and stateless HTTP calls. However, that's a breaking change best suited for a major release. Happy to contribute that work separately if there is interest.