### PR TITLE
Add RFC 5322 compliant Message-ID header to email notifications

### DIFF
--- a/internal/notif/mail/client_test.go
+++ b/internal/notif/mail/client_test.go
@@ -1,0 +1,127 @@
+package mail
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/crazy-max/diun/v4/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateMessageID(t *testing.T) {
+	// RFC 5322 Message-ID format: <local-part@domain>
+	// local-part should contain: timestamp.randomhex
+	messageIDRegex := regexp.MustCompile(`^<\d+\.[0-9a-f]+@.+>$`)
+
+	tests := []struct {
+		name       string
+		cfg        *model.NotifMail
+		wantDomain string
+	}{
+		{
+			name: "with LocalName",
+			cfg: &model.NotifMail{
+				Host:      "smtp.example.com",
+				LocalName: "mail.mydomain.com",
+			},
+			wantDomain: "mail.mydomain.com",
+		},
+		{
+			name: "fallback to Host",
+			cfg: &model.NotifMail{
+				Host:      "smtp.example.com",
+				LocalName: "",
+			},
+			wantDomain: "smtp.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &Client{
+				cfg: tt.cfg,
+			}
+
+			messageID, err := client.generateMessageID()
+			require.NoError(t, err, "generateMessageID should not return an error")
+			assert.NotEmpty(t, messageID, "Message-ID should not be empty")
+
+			// Verify RFC 5322 format
+			assert.True(t, messageIDRegex.MatchString(messageID),
+				"Message-ID should match RFC 5322 format: %s", messageID)
+
+			// Verify it contains the expected domain
+			assert.Contains(t, messageID, tt.wantDomain,
+				"Message-ID should contain domain %s: %s", tt.wantDomain, messageID)
+
+			// Verify structure: <timestamp.randomhex@domain>
+			assert.True(t, strings.HasPrefix(messageID, "<"), "Message-ID should start with <")
+			assert.True(t, strings.HasSuffix(messageID, ">"), "Message-ID should end with >")
+			assert.Contains(t, messageID, "@", "Message-ID should contain @")
+			assert.Contains(t, messageID, ".", "Message-ID should contain . separator")
+		})
+	}
+}
+
+func TestGenerateMessageID_Uniqueness(t *testing.T) {
+	client := &Client{
+		cfg: &model.NotifMail{
+			Host:      "smtp.example.com",
+			LocalName: "mail.example.com",
+		},
+	}
+
+	// Generate multiple Message-IDs and verify they are unique
+	messageIDs := make(map[string]bool)
+	iterations := 1000
+
+	for i := 0; i < iterations; i++ {
+		messageID, err := client.generateMessageID()
+		require.NoError(t, err)
+		assert.False(t, messageIDs[messageID], "Message-ID should be unique: %s", messageID)
+		messageIDs[messageID] = true
+	}
+
+	assert.Len(t, messageIDs, iterations, "All generated Message-IDs should be unique")
+}
+
+func TestGenerateMessageID_Format(t *testing.T) {
+	client := &Client{
+		cfg: &model.NotifMail{
+			Host:      "smtp.example.com",
+			LocalName: "mail.example.com",
+		},
+	}
+
+	messageID, err := client.generateMessageID()
+	require.NoError(t, err)
+
+	// Remove angle brackets
+	messageID = strings.TrimPrefix(messageID, "<")
+	messageID = strings.TrimSuffix(messageID, ">")
+
+	// Split by @
+	parts := strings.Split(messageID, "@")
+	require.Len(t, parts, 2, "Message-ID should have exactly one @ symbol")
+
+	localPart := parts[0]
+	domain := parts[1]
+
+	// Verify local part contains timestamp.randomhex
+	localParts := strings.Split(localPart, ".")
+	require.Len(t, localParts, 2, "Local part should be timestamp.randomhex")
+
+	// Verify timestamp is numeric
+	timestamp := localParts[0]
+	assert.Regexp(t, `^\d+$`, timestamp, "Timestamp should be numeric")
+
+	// Verify random part is hex (16 characters for 8 bytes)
+	randomHex := localParts[1]
+	assert.Len(t, randomHex, 16, "Random hex should be 16 characters (8 bytes)")
+	assert.Regexp(t, `^[0-9a-f]+$`, randomHex, "Random part should be hex")
+
+	// Verify domain
+	assert.Equal(t, "mail.example.com", domain, "Domain should match LocalName")
+}


### PR DESCRIPTION
## Summary

This PR implements automatic generation of RFC 5322 compliant Message-ID headers for all email notifications sent by diun.

Currently, diun email notifications do not include a Message-ID header, which can cause issues with:
- Email threading and tracking in mail clients
- Spam filtering systems  
- RFC 5322 compliance

## Changes

- **New function `generateMessageID()`** in `internal/notif/mail/client.go`:
  - Generates unique Message-IDs using nanosecond timestamps for high resolution
  - Includes 8 bytes of cryptographically secure random data (hex encoded)
  - Format: `<timestamp.randomhex@domain>`
  - Domain is taken from `LocalName` config if set, otherwise falls back to `Host`
  
- **Integration in `Send()` method**:
  - Message-ID is generated before sending each email
  - Header is set using `mailMessage.SetHeader("Message-ID", messageID)`
  
- **Comprehensive unit tests** in `internal/notif/mail/client_test.go`:
  - `TestGenerateMessageID`: Validates format with LocalName and Host fallback
  - `TestGenerateMessageID_Uniqueness`: Verifies uniqueness across 1000 iterations
  - `TestGenerateMessageID_Format`: Validates RFC 5322 format compliance

## Benefits

✅ Improves email threading and tracking in mail clients  
✅ Enhances spam filter compatibility  
✅ Ensures RFC 5322 compliance for all outgoing notifications  
✅ Each message gets a globally unique identifier

## Testing

All tests pass successfully:
```
=== RUN   TestGenerateMessageID
=== RUN   TestGenerateMessageID/with_LocalName
=== RUN   TestGenerateMessageID/fallback_to_Host
--- PASS: TestGenerateMessageID (0.00s)
=== RUN   TestGenerateMessageID_Uniqueness
--- PASS: TestGenerateMessageID_Uniqueness (0.00s)
=== RUN   TestGenerateMessageID_Format
--- PASS: TestGenerateMessageID_Format (0.00s)
PASS
coverage: 16.4% of statements
ok  	github.com/crazy-max/diun/v4/internal/notif/mail
```

Tested with: `docker buildx bake test`

## Implementation Details

The Message-ID generation follows RFC 5322 best practices:
- Uses highest-resolution clock (nanoseconds) for timestamp component
- Includes cryptographically secure randomness (64 bits) for uniqueness
- Properly formatted as `<local-part@domain>`
- Domain component ensures global uniqueness guarantee

Example generated Message-ID:
```
<1733837213123456789.a1b2c3d4e5f6a7b8@mail.example.com>
```