### PR TITLE
feat(kubernetes): add namespacesExclude option to ignore namespaces

### DIFF
--- a/docs/providers/kubernetes.md
+++ b/docs/providers/kubernetes.md
@@ -263,6 +263,26 @@ Array of namespaces to watch (default all namespaces).
 !!! abstract "Environment variables"
     * `DIUN_PROVIDERS_KUBERNETES_NAMESPACES` (comma separated)
 
+
+### `namespacesExclude`
+
+Array of namespaces to exclude from watching. This is useful when you want to watch all namespaces
+except specific ones (e.g., system namespaces like kube-system, kube-public). Takes precedence over
+`namespaces` - if a namespace is in both lists, it will be excluded.
+
+!!! example "File"
+    ```yaml
+    providers:
+      kubernetes:
+        namespacesExclude:
+          - kube-system
+          - kube-public
+          - kube-node-lease
+    ```
+
+!!! abstract "Environment variables"
+    * `DIUN_PROVIDERS_KUBERNETES_NAMESPACESEXCLUDE` (comma separated)
+
 ### `watchByDefault`
 
 Enable watch by default. If false, pods that don't have `diun.enable: "true"` annotation will be ignored

--- a/internal/model/provider_kubernetes.go
+++ b/internal/model/provider_kubernetes.go
@@ -1,18 +1,19 @@
 package model
 
 import (
-	"github.com/crazy-max/diun/v4/pkg/utl"
+"github.com/crazy-max/diun/v4/pkg/utl"
 )
 
 // PrdKubernetes holds kubernetes provider configuration
 type PrdKubernetes struct {
-	Endpoint         string   `yaml:"endpoint" json:"endpoint,omitempty" validate:"omitempty"`
-	Token            string   `yaml:"token,omitempty" json:"token,omitempty" validate:"omitempty"`
-	TokenFile        string   `yaml:"tokenFile,omitempty" json:"tokenFile,omitempty" validate:"omitempty,file"`
-	CertAuthFilePath string   `yaml:"certAuthFilePath" json:"certAuthFilePath,omitempty" validate:"omitempty"`
-	TLSInsecure      *bool    `yaml:"tlsInsecure" json:"tlsInsecure,omitempty" validate:"required"`
-	Namespaces       []string `yaml:"namespaces" json:"namespaces,omitempty" validate:"omitempty"`
-	WatchByDefault   *bool    `yaml:"watchByDefault" json:"watchByDefault,omitempty" validate:"required"`
+	Endpoint          string   `yaml:"endpoint" json:"endpoint,omitempty" validate:"omitempty"`
+	Token             string   `yaml:"token,omitempty" json:"token,omitempty" validate:"omitempty"`
+	TokenFile         string   `yaml:"tokenFile,omitempty" json:"tokenFile,omitempty" validate:"omitempty,file"`
+	CertAuthFilePath  string   `yaml:"certAuthFilePath" json:"certAuthFilePath,omitempty" validate:"omitempty"`
+	TLSInsecure       *bool    `yaml:"tlsInsecure" json:"tlsInsecure,omitempty" validate:"required"`
+	Namespaces        []string `yaml:"namespaces" json:"namespaces,omitempty" validate:"omitempty"`
+	NamespacesExclude []string `yaml:"namespacesExclude" json:"namespacesExclude,omitempty" validate:"omitempty"`
+	WatchByDefault    *bool    `yaml:"watchByDefault" json:"watchByDefault,omitempty" validate:"required"`
 }
 
 // GetDefaults gets the default values

--- a/internal/provider/kubernetes/pod.go
+++ b/internal/provider/kubernetes/pod.go
@@ -18,7 +18,8 @@ func (c *Client) listPodImage() []model.Image {
 		TokenFile:        c.config.TokenFile,
 		CertAuthFilePath: c.config.CertAuthFilePath,
 		TLSInsecure:      c.config.TLSInsecure,
-		Namespaces:       c.config.Namespaces,
+		Namespaces:        c.config.Namespaces,
+		NamespacesExclude: c.config.NamespacesExclude,
 	})
 	if err != nil {
 		c.logger.Error().Err(err).Msg("Cannot create Kubernetes client")

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -1,33 +1,35 @@
 package k8s
 
 import (
-	"context"
-	"os"
+"context"
+"os"
 
-	"github.com/crazy-max/diun/v4/pkg/utl"
-	"github.com/pkg/errors"
-	"github.com/rs/zerolog/log"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
+"github.com/crazy-max/diun/v4/pkg/utl"
+"github.com/pkg/errors"
+"github.com/rs/zerolog/log"
+metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+"k8s.io/client-go/kubernetes"
+"k8s.io/client-go/rest"
+"k8s.io/client-go/tools/clientcmd"
 )
 
 // Client represents an active kubernetes object
 type Client struct {
-	ctx        context.Context
-	namespaces []string
-	API        *kubernetes.Clientset
+	ctx               context.Context
+	namespaces        []string
+	namespacesExclude []string
+	API               *kubernetes.Clientset
 }
 
 // Options holds kubernetes client object options
 type Options struct {
-	Endpoint         string
-	Token            string
-	TokenFile        string
-	CertAuthFilePath string
-	TLSInsecure      *bool
-	Namespaces       []string
+	Endpoint          string
+	Token             string
+	TokenFile         string
+	CertAuthFilePath  string
+	TLSInsecure       *bool
+	Namespaces        []string
+	NamespacesExclude []string
 }
 
 // New initializes a new Kubernetes client
@@ -52,10 +54,21 @@ func New(opts Options) (*Client, error) {
 	}
 
 	return &Client{
-		ctx:        context.Background(),
-		namespaces: opts.Namespaces,
-		API:        api,
+		ctx:               context.Background(),
+		namespaces:        opts.Namespaces,
+		namespacesExclude: opts.NamespacesExclude,
+		API:               api,
 	}, err
+}
+
+// IsNamespaceExcluded checks if a namespace is in the exclusion list
+func (c *Client) IsNamespaceExcluded(namespace string) bool {
+	for _, ns := range c.namespacesExclude {
+		if ns == namespace {
+			return true
+		}
+	}
+	return false
 }
 
 func newInClusterClient(opts Options) (*kubernetes.Clientset, error) {

--- a/pkg/k8s/pod.go
+++ b/pkg/k8s/pod.go
@@ -1,10 +1,10 @@
 package k8s
 
 import (
-	"sort"
+"sort"
 
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+v1 "k8s.io/api/core/v1"
+metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // PodList returns Kubernetes pods
@@ -17,12 +17,16 @@ func (c *Client) PodList(opts metav1.ListOptions) ([]v1.Pod, error) {
 			return nil, err
 		}
 		for _, pod := range pods.Items {
+			// Skip pods in excluded namespaces
+			if c.IsNamespaceExcluded(pod.Namespace) {
+				continue
+			}
 			podList = appendPod(podList, pod)
 		}
 	}
 
 	sort.Slice(podList, func(i, j int) bool {
-		return podList[i].Name < podList[j].Name
+return podList[i].Name < podList[j].Name
 	})
 
 	return podList, nil


### PR DESCRIPTION
## Description

Add a new `namespacesExclude` configuration option for the Kubernetes provider that allows users to exclude specific namespaces from being watched.

This is useful when users want to watch all namespaces except specific system namespaces (e.g., `kube-system`, `kube-public`, `kube-node-lease`) without having to explicitly list all namespaces they want to include.

## Example Configuration

```yaml
providers:
  kubernetes:
    namespacesExclude:
      - kube-system
      - kube-public
      - kube-node-lease
```

Or via environment variable:
```
DIUN_PROVIDERS_KUBERNETES_NAMESPACESEXCLUDE=kube-system,kube-public,kube-node-lease
```

## Changes

- Add `NamespacesExclude` field to `PrdKubernetes` model
- Add `NamespacesExclude` to `k8s.Options` and `k8s.Client`
- Add `IsNamespaceExcluded` helper method to `k8s.Client`
- Filter out excluded namespaces in `PodList`
- Update Kubernetes provider to pass `NamespacesExclude` to k8s client
- Add documentation for the new option

## Behavior

- If a namespace is in both `namespaces` (include) and `namespacesExclude`, it will be **excluded**
- Works with the default "all namespaces" behavior - you can watch all namespaces except the ones you exclude
- Comma-separated list supported for environment variable configuration

Fixes #1341