### PR TITLE
notif(discord): add renderEmbeds option

### DIFF
--- a/docs/notif/discord.md
+++ b/docs/notif/discord.md
@@ -15,6 +15,7 @@ Allow sending notifications to your Discord channel.
           - "<@124>"
           - "<@125>"
           - "<@&200>"
+        renderEmbeds: true
         renderFields: true
         timeout: 10s
         templateBody: |
@@ -26,7 +27,8 @@ Allow sending notifications to your Discord channel.
 | `webhookURL`       |                                    | Discord [incoming webhook URL](https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks) |
 | `webhookURLFile`   |                                    | Use content of secret file as webhook URL if `webhookURL` is not defined                                  |
 | `mentions`         |                                    | List of users or roles to notify                                                                          |
-| `renderFields`     | `true`                             | Render [field objects](https://discordjs.guide/popular-topics/embeds.html)                                |
+| `renderEmbeds`     | `true`                             | Render [message embeds](https://discordjs.guide/legacy/popular-topics/embeds)                             |
+| `renderFields`     | `true`                             | Render [field objects](https://discordjs.guide/legacy/popular-topics/embeds) in message embeds            |
 | `timeout`          | `10s`                              | Timeout specifies a time limit for the request to be made                                                 |
 | `templateBody`[^1] | See [below](#default-templatebody) | [Notification template](../faq.md#notification-template) for message body                                 |
 
@@ -34,6 +36,7 @@ Allow sending notifications to your Discord channel.
     * `DIUN_NOTIF_DISCORD_WEBHOOKURL`
     * `DIUN_NOTIF_DISCORD_WEBHOOKURLFILE`
     * `DIUN_NOTIF_DISCORD_MENTIONS` (comma separated)
+    * `DIUN_NOTIF_DISCORD_RENDEREMBEDS`
     * `DIUN_NOTIF_DISCORD_RENDERFIELDS`
     * `DIUN_NOTIF_DISCORD_TIMEOUT`
     * `DIUN_NOTIF_DISCORD_TEMPLATEBODY`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -90,6 +90,7 @@ func TestLoadFile(t *testing.T) {
 							"<@125>",
 							"<@&200>",
 						},
+						RenderEmbeds: utl.NewTrue(),
 						RenderFields: utl.NewTrue(),
 						Timeout:      utl.NewDuration(10 * time.Second),
 						TemplateBody: model.NotifDefaultTemplateBody,

--- a/internal/model/notif_discord.go
+++ b/internal/model/notif_discord.go
@@ -11,6 +11,7 @@ type NotifDiscord struct {
 	WebhookURL     string         `yaml:"webhookURL,omitempty" json:"webhookURL,omitempty" validate:"omitempty"`
 	WebhookURLFile string         `yaml:"webhookURLFile,omitempty" json:"webhookURLFile,omitempty" validate:"omitempty,file"`
 	Mentions       []string       `yaml:"mentions,omitempty" json:"mentions,omitempty"`
+	RenderEmbeds   *bool          `yaml:"renderEmbeds,omitempty" json:"renderEmbeds,omitempty" validate:"required"`
 	RenderFields   *bool          `yaml:"renderFields,omitempty" json:"renderFields,omitempty" validate:"required"`
 	Timeout        *time.Duration `yaml:"timeout,omitempty" json:"timeout,omitempty" validate:"required"`
 	TemplateBody   string         `yaml:"templateBody,omitempty" json:"templateBody,omitempty" validate:"required"`
@@ -25,6 +26,7 @@ func (s *NotifDiscord) GetDefaults() *NotifDiscord {
 
 // SetDefaults sets the default values
 func (s *NotifDiscord) SetDefaults() {
+	s.RenderEmbeds = utl.NewTrue()
 	s.RenderFields = utl.NewTrue()
 	s.Timeout = utl.NewDuration(10 * time.Second)
 	s.TemplateBody = NotifDefaultTemplateBody


### PR DESCRIPTION
fixes #614 
closes #1355 

Add `renderEmbeds` option to enable/disable message embeds rendering.