### PR TITLE
feat: add configurable Telegram API URL for proxy support

### DIFF
--- a/docs/notif/telegram.md
+++ b/docs/notif/telegram.md
@@ -25,22 +25,22 @@ Multiple chat IDs can be provided in order to deliver notifications to multiple 
 
 | Name                  | Default                            | Description                                                                                                                          |
 |-----------------------|------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
+| `apiURL`              | `https://api.telegram.org`         | Custom Telegram bot API base URL, for proxies or self-hosted bot API servers                                                         |
 | `token`               |                                    | Telegram bot token                                                                                                                   |
 | `tokenFile`           |                                    | Use content of [secret file](../faq.md#secrets-loaded-from-files-and-trailing-newlines) as Telegram bot token if `token` not defined |
 | `chatIDs`             |                                    | List of [chat IDs](#chatids-format) to send notifications to                                                                         |
 | `chatIDsFile`         |                                    | Use content of [secret file](../faq.md#secrets-loaded-from-files-and-trailing-newlines) as chat IDs if `chatIDs` not defined         |
 | `templateBody`[^1]    | See [below](#default-templatebody) | [Notification template](../faq.md#notification-template) for message body                                                            |
 | `disableNotification` | `false`                            | Send silent message with no sound                                                                                                    |
-| `apiURL`              | `https://api.telegram.org`         | Telegram Bot API URL, useful to set a proxy                                                                                          |
 
 !!! abstract "Environment variables"
+    * `DIUN_NOTIF_TELEGRAM_APIURL`
     * `DIUN_NOTIF_TELEGRAM_TOKEN`
     * `DIUN_NOTIF_TELEGRAM_TOKENFILE`
     * `DIUN_NOTIF_TELEGRAM_CHATIDS` (comma separated)
     * `DIUN_NOTIF_TELEGRAM_CHATIDSFILE`
     * `DIUN_NOTIF_TELEGRAM_TEMPLATEBODY`
     * `DIUN_NOTIF_TELEGRAM_DISABLENOTIFICATION`
-    * `DIUN_NOTIF_TELEGRAM_APIURL`
 
 !!! example "chat IDs secret file"
     Chat IDs secret file must be a valid JSON array like: `["123456789","987654321","567891234:25","891256734:25;12"]`

--- a/docs/notif/telegram.md
+++ b/docs/notif/telegram.md
@@ -31,6 +31,7 @@ Multiple chat IDs can be provided in order to deliver notifications to multiple 
 | `chatIDsFile`         |                                    | Use content of [secret file](../faq.md#secrets-loaded-from-files-and-trailing-newlines) as chat IDs if `chatIDs` not defined         |
 | `templateBody`[^1]    | See [below](#default-templatebody) | [Notification template](../faq.md#notification-template) for message body                                                            |
 | `disableNotification` | `false`                            | Send silent message with no sound                                                                                                    |
+| `apiURL`              | `https://api.telegram.org`         | Telegram Bot API URL, useful to set a proxy                                                                                          |
 
 !!! abstract "Environment variables"
     * `DIUN_NOTIF_TELEGRAM_TOKEN`
@@ -39,6 +40,7 @@ Multiple chat IDs can be provided in order to deliver notifications to multiple 
     * `DIUN_NOTIF_TELEGRAM_CHATIDSFILE`
     * `DIUN_NOTIF_TELEGRAM_TEMPLATEBODY`
     * `DIUN_NOTIF_TELEGRAM_DISABLENOTIFICATION`
+    * `DIUN_NOTIF_TELEGRAM_APIURL`
 
 !!! example "chat IDs secret file"
     Chat IDs secret file must be a valid JSON array like: `["123456789","987654321","567891234:25","891256734:25;12"]`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/PaulSonOfLars/gotgbot/v2"
 	"github.com/crazy-max/diun/v4/internal/model"
 	"github.com/crazy-max/diun/v4/pkg/registry"
 	"github.com/crazy-max/diun/v4/pkg/utl"
@@ -193,7 +194,8 @@ for <code>{{ .Entry.Manifest.Platform }}</code> platform.
 						TemplateBody: model.NotifTeamsDefaultTemplateBody,
 					},
 					Telegram: &model.NotifTelegram{
-						Token: "abcdef123456",
+						APIURL: gotgbot.DefaultAPIURL,
+						Token:  "abcdef123456",
 						ChatIDs: []string{
 							"8547439",
 							"1234567",
@@ -347,6 +349,7 @@ func TestLoadEnv(t *testing.T) {
 			environ: []string{
 				"DIUN_NOTIF_TELEGRAM_TOKEN=abcdef123456",
 				"DIUN_NOTIF_TELEGRAM_CHATIDS=8547439,1234567",
+				"DIUN_NOTIF_TELEGRAM_APIURL=http://telegram-bot-api:8081",
 				"DIUN_PROVIDERS_SWARM=true",
 			},
 			expected: &Config{
@@ -362,6 +365,7 @@ func TestLoadEnv(t *testing.T) {
 						},
 						TemplateBody:        model.NotifTelegramDefaultTemplateBody,
 						DisableNotification: utl.NewFalse(),
+						APIURL:              "http://telegram-bot-api:8081",
 					},
 				},
 				Providers: &model.Providers{

--- a/internal/model/notif_telegram.go
+++ b/internal/model/notif_telegram.go
@@ -13,6 +13,7 @@ type NotifTelegram struct {
 	ChatIDsFile         string   `yaml:"chatIDsFile,omitempty" json:"chatIDsFile,omitempty" validate:"omitempty,file"`
 	TemplateBody        string   `yaml:"templateBody,omitempty" json:"templateBody,omitempty" validate:"required"`
 	DisableNotification *bool    `yaml:"disableNotification,omitempty" json:"disableNotification,omitempty" validate:"omitempty"`
+	APIURL              string   `yaml:"apiURL,omitempty" json:"apiURL,omitempty" validate:"omitempty,url"`
 }
 
 // GetDefaults gets the default values

--- a/internal/model/notif_telegram.go
+++ b/internal/model/notif_telegram.go
@@ -1,19 +1,22 @@
 package model
 
-import "github.com/crazy-max/diun/v4/pkg/utl"
+import (
+	"github.com/PaulSonOfLars/gotgbot/v2"
+	"github.com/crazy-max/diun/v4/pkg/utl"
+)
 
 // NotifTelegramDefaultTemplateBody ...
 const NotifTelegramDefaultTemplateBody = `Docker tag {{ if .Entry.Image.HubLink }}[{{ .Entry.Image }}]({{ .Entry.Image.HubLink }}){{ else }}{{ .Entry.Image }}{{ end }} which you subscribed to through {{ .Entry.Provider }} provider {{ if (eq .Entry.Status "new") }}is available{{ else }}has been updated{{ end }} on {{ .Entry.Image.Domain }} registry (triggered by {{ escapeMarkdown .Meta.Hostname }} host).`
 
 // NotifTelegram holds Telegram notification configuration details
 type NotifTelegram struct {
+	APIURL              string   `yaml:"apiURL,omitempty" json:"apiURL,omitempty" validate:"omitempty,url"`
 	Token               string   `yaml:"token,omitempty" json:"token,omitempty" validate:"omitempty"`
 	TokenFile           string   `yaml:"tokenFile,omitempty" json:"tokenFile,omitempty" validate:"omitempty,file"`
 	ChatIDs             []string `yaml:"chatIDs,omitempty" json:"chatIDs,omitempty" validate:"omitempty"`
 	ChatIDsFile         string   `yaml:"chatIDsFile,omitempty" json:"chatIDsFile,omitempty" validate:"omitempty,file"`
 	TemplateBody        string   `yaml:"templateBody,omitempty" json:"templateBody,omitempty" validate:"required"`
 	DisableNotification *bool    `yaml:"disableNotification,omitempty" json:"disableNotification,omitempty" validate:"omitempty"`
-	APIURL              string   `yaml:"apiURL,omitempty" json:"apiURL,omitempty" validate:"omitempty,url"`
 }
 
 // GetDefaults gets the default values
@@ -25,6 +28,7 @@ func (s *NotifTelegram) GetDefaults() *NotifTelegram {
 
 // SetDefaults sets the default values
 func (s *NotifTelegram) SetDefaults() {
+	s.APIURL = gotgbot.DefaultAPIURL
 	s.TemplateBody = NotifTelegramDefaultTemplateBody
 	s.DisableNotification = utl.NewFalse()
 }

--- a/internal/notif/telegram/client.go
+++ b/internal/notif/telegram/client.go
@@ -42,14 +42,6 @@ func (c *Client) Name() string {
 	return "telegram"
 }
 
-// apiURL returns the Telegram Bot API URL, falling back to the default if not configured.
-func (c *Client) apiURL() string {
-	if c.cfg.APIURL != "" {
-		return c.cfg.APIURL
-	}
-	return gotgbot.DefaultAPIURL
-}
-
 // Send creates and sends a Telegram notification with an entry
 func (c *Client) Send(entry model.NotifEntry) error {
 	token, err := utl.GetSecret(c.cfg.Token, c.cfg.TokenFile)
@@ -81,7 +73,7 @@ func (c *Client) Send(entry model.NotifEntry) error {
 			Client: http.Client{},
 			DefaultRequestOpts: &gotgbot.RequestOpts{
 				Timeout: gotgbot.DefaultTimeout,
-				APIURL:  c.apiURL(),
+				APIURL:  c.cfg.APIURL,
 			},
 		},
 	})

--- a/internal/notif/telegram/client.go
+++ b/internal/notif/telegram/client.go
@@ -42,6 +42,14 @@ func (c *Client) Name() string {
 	return "telegram"
 }
 
+// apiURL returns the Telegram Bot API URL, falling back to the default if not configured.
+func (c *Client) apiURL() string {
+	if c.cfg.APIURL != "" {
+		return c.cfg.APIURL
+	}
+	return gotgbot.DefaultAPIURL
+}
+
 // Send creates and sends a Telegram notification with an entry
 func (c *Client) Send(entry model.NotifEntry) error {
 	token, err := utl.GetSecret(c.cfg.Token, c.cfg.TokenFile)
@@ -73,7 +81,7 @@ func (c *Client) Send(entry model.NotifEntry) error {
 			Client: http.Client{},
 			DefaultRequestOpts: &gotgbot.RequestOpts{
 				Timeout: gotgbot.DefaultTimeout,
-				APIURL:  gotgbot.DefaultAPIURL,
+				APIURL:  c.apiURL(),
 			},
 		},
 	})


### PR DESCRIPTION
This PR adds the ability to override the default Telegram Bot API URL (`https://api.telegram.org`). This is primarily useful for users who need to route their Telegram notifications through a custom proxy or want to use a local Telegram Bot API server.

**Changes:**
 * Added `apiURL` field to the Telegram config and the corresponding `DIUN_NOTIF_TELEGRAM_APIURL` environment variable.
 * Updated the `gotgbot` client initialization to use the custom URL if provided (falls back to the default one otherwise).
 * Updated the documentation.

Closes #1536