### PR TITLE
MkDocs Materials 9.7.5

### DIFF
--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,6 +1,6 @@
 # Support [![](https://isitmaintained.com/badge/resolution/crazy-max/diun.svg)](https://isitmaintained.com/project/crazy-max/diun)
 
-First, [be a good guy](https://github.com/kossnocorp/etiquette/blob/master/README.md).
+First, [be respectful](https://github.com/kossnocorp/opensource.how/blob/classic/README.md).
 
 ## Reporting an issue
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,381 +2,381 @@
 
 ## 4.31.0 (2025/12/24)
 
-* Support for negating namespaces with Kubernetes provider (#1582)
-* Support new Matrix servers for Matrix notifications (#1529 #1551)
-* Use `X-Gotify-Key` header to send token for Gotify (#1530)
-* Add RFC 5322 compliant Message-ID header to email notifications (#1557)
-* Add `renderEmbeds` option for Discord notifications (#1580)
-* Go 1.25 (#1573)
-* Alpine Linux 3.23 (#1572)
-* MkDocs Material 9.6.20 (#1509)
-* Bump github.com/alecthomas/kong to 1.13.0 (#1545)
-* Bump github.com/containerd/platforms to 1.0.0-rc.2 (#1533)
-* Bump github.com/docker/docker to 28.5.2+incompatible (#1517)
-* Bump github.com/dromara/carbon/v2 to 2.6.15 (#1526 #1546)
-* Bump github.com/eclipse/paho.mqtt.golang to 1.5.1 (#1504)
-* Bump github.com/jedib0t/go-pretty/v6 to 6.7.8 (#1569 #1583)
-* Bump github.com/go-playground/validator/v10 to 10.30.0 (#1513 #1576)
-* Bump github.com/hashicorp/nomad/api to 1.11.1 (#1579)
-* Bump github.com/moby/buildkit to 0.25.3 (#1516 #1566)
-* Bump go.podman.io/image/v5 to 5.38.0 (#1502 #1535)
-* Bump golang.org/x/mod to 0.30.0 (#1540)
-* Bump google.golang.org/grpc to 1.78.0 (#1565 #1584)
-* Bump google.golang.org/grpc/cmd/protoc-gen-go-grpc to 1.6.0 (#1577)
-* Bump google.golang.org/protobuf to 1.36.11 (#1564)
-* Bump k8s.io/client-go to 0.34.1 (#1501)
-* Bump maunium.net/go/mautrix from 0.25.2 to 0.26.1 (#1567)
+* Support for negating namespaces with Kubernetes provider by @crazy-max in #1582
+* Support new Matrix servers for Matrix notifications by @artgpz, @sreinwald in #1529 #1551
+* Use `X-Gotify-Key` header to send token for Gotify by @crazy-max in #1530
+* Add RFC 5322 compliant Message-ID header to email notifications by @tkaufmann in #1557
+* Add `renderEmbeds` option for Discord notifications by @crazy-max in #1580
+* Go 1.25 by @crazy-max in #1573
+* Alpine Linux 3.23 by @crazy-max in #1572
+* MkDocs Material 9.6.20 by @crazy-max in #1509
+* Bump github.com/alecthomas/kong to 1.13.0 in #1545
+* Bump github.com/containerd/platforms to 1.0.0-rc.2 in #1533
+* Bump github.com/docker/docker to 28.5.2+incompatible in #1517
+* Bump github.com/dromara/carbon/v2 to 2.6.15 in #1526 #1546
+* Bump github.com/eclipse/paho.mqtt.golang to 1.5.1 in #1504
+* Bump github.com/jedib0t/go-pretty/v6 to 6.7.8 in #1569 #1583
+* Bump github.com/go-playground/validator/v10 to 10.30.0 in #1513 #1576
+* Bump github.com/hashicorp/nomad/api to 1.11.1 by @crazy-max in #1579
+* Bump github.com/moby/buildkit to 0.25.3 in #1516 #1566
+* Bump go.podman.io/image/v5 to 5.38.0 by @crazy-max in #1502 #1535
+* Bump golang.org/x/mod to 0.30.0 in #1540
+* Bump google.golang.org/grpc to 1.78.0 in #1565 #1584
+* Bump google.golang.org/grpc/cmd/protoc-gen-go-grpc to 1.6.0 in #1577
+* Bump google.golang.org/protobuf to 1.36.11 in #1564
+* Bump k8s.io/client-go to 0.34.1 in #1501
+* Bump maunium.net/go/mautrix to 0.26.1 in #1567
 
 ## 4.30.0 (2025/08/31)
 
-* Add TLS config options `tlsSkipVerify` and `tlsCaCertFiles` for all notifiers using an HTTP client (#1489)
-* Apprise notifications support (#1457)
-* Elasticsearch notifications support (#1452)
-* Add `disableNotification` option for Telegram (#1354)
-* Switch from third-party module to HTTP client for Pushover (#1490)
-* Align `chatIDs` and `chatIDsFile` format handling for Telegram (#1316)
-* Switch from `github.com/hako/durafmt` to `github.com/dromara/carbon` module (#1317)
-* Remove unneeded `openssl` package in the Docker image (#1488)
-* Go 1.24 (#1461)
-* Alpine Linux 3.22 (#1462)
-* Bump dario.cat/mergo to 1.0.2 (#1436)
-* Bump github.com/alecthomas/kong to 1.12.1 (#1324 #1456)
-* Bump github.com/containers/image/v5 to 5.36.1 (#1340 #1454 #1467)
-* Bump github.com/crazy-max/gohealthchecks to 0.5.0 (#1319)
-* Bump github.com/docker/docker to 28.3.3+incompatible (#1458)
-* Bump github.com/docker/go-connections to 0.6.0 (#1470)
-* Bump github.com/dromara/carbon/v2 to 2.6.11 (#1435 #1455)
-* Bump github.com/go-playground/validator/v10 to 10.27.0 (#1333 #1432 #1446)
-* Bump github.com/hashicorp/nomad/api to 1.10.4 (#1487)
-* Bump github.com/jedib0t/go-pretty/v6 to 6.6.8 (#1430 #1466)
-* Bump github.com/moby/buildkit to 0.23.2 (#1445)
-* Bump github.com/opencontainers/image-spec to 1.1.1 (#1434)
-* Bump github.com/panjf2000/ants/v2 to 2.11.3 (#1331 #1433)
-* Bump github.com/PaulSonOfLars/gotgbot/v2 to 2.0.0-rc.33 (#1397 #1448)
-* Bump github.com/rs/zerolog to 1.34.0 (#1431)
-* Bump github.com/stretchr/testify to 1.11.1 (#1482)
-* Bump go.etcd.io/bbolt to 1.4.3 (#1361 #1444 #1477)
-* Bump golang.org/x/crypto to 0.35.0 (#1398)
-* Bump golang.org/x/mod to 0.27.0 (#1377 #1450 #1469)
-* Bump golang.org/x/net to 0.38.0 (#1343 #1402)
-* Bump golang.org/x/sys to 0.35.0 (#1323 #1427 #1472)
-* Bump google.golang.org/grpc to 1.74.2 (#1407 #1465)
-* Bump google.golang.org/protobuf to 1.36.8 (#1389 #1471 #1479)
-* Bump k8s.io/client-go to 0.32.1 (#1338 #1453)
+* Add TLS config options `tlsSkipVerify` and `tlsCaCertFiles` for all notifiers using an HTTP client by @crazy-max in #1489
+* Apprise notifications support by @privacyfr3ak in #1457
+* Elasticsearch notifications support by @robin-moser in #1452
+* Add `disableNotification` option for Telegram by @imrebuild in #1354
+* Switch from third-party module to HTTP client for Pushover by @crazy-max in #1490
+* Align `chatIDs` and `chatIDsFile` format handling for Telegram by @crazy-max in #1316
+* Switch from `github.com/hako/durafmt` to `github.com/dromara/carbon` module by @crazy-max in #1317
+* Remove unneeded `openssl` package in the Docker image by @crazy-max in #1488
+* Go 1.24 by @crazy-max in #1461
+* Alpine Linux 3.22 by @crazy-max in #1462
+* Bump dario.cat/mergo to 1.0.2 in #1436
+* Bump github.com/alecthomas/kong to 1.12.1 in #1324 #1456
+* Bump github.com/containers/image/v5 to 5.36.1 in #1340 #1454 #1467
+* Bump github.com/crazy-max/gohealthchecks to 0.5.0 in #1319
+* Bump github.com/docker/docker to 28.3.3+incompatible in #1458
+* Bump github.com/docker/go-connections to 0.6.0 in #1470
+* Bump github.com/dromara/carbon/v2 to 2.6.11 in #1435 #1455
+* Bump github.com/go-playground/validator/v10 to 10.27.0 in #1333 #1432 #1446
+* Bump github.com/hashicorp/nomad/api to 1.10.4 by @crazy-max in #1487
+* Bump github.com/jedib0t/go-pretty/v6 to 6.6.8 in #1430 #1466
+* Bump github.com/moby/buildkit to 0.23.2 in #1445
+* Bump github.com/opencontainers/image-spec to 1.1.1 in #1434
+* Bump github.com/panjf2000/ants/v2 to 2.11.3 in #1331 #1433
+* Bump github.com/PaulSonOfLars/gotgbot/v2 to 2.0.0-rc.33 in #1397 #1448
+* Bump github.com/rs/zerolog to 1.34.0 in #1431
+* Bump github.com/stretchr/testify to 1.11.1 in #1482
+* Bump go.etcd.io/bbolt to 1.4.3 in #1361 #1444 #1477
+* Bump golang.org/x/crypto to 0.35.0 in #1398
+* Bump golang.org/x/mod to 0.27.0 in #1377 #1450 #1469
+* Bump golang.org/x/net to 0.38.0 in #1343 #1402
+* Bump golang.org/x/sys to 0.35.0 in #1323 #1427 #1472
+* Bump google.golang.org/grpc to 1.74.2 in #1407 #1465
+* Bump google.golang.org/protobuf to 1.36.8 in #1389 #1471 #1479
+* Bump k8s.io/client-go to 0.32.1 in #1338 #1453
 
 ## 4.29.0 (2024/12/19)
 
 :warning: See **Migration notes** in the documentation before upgrading.
 
-* Topics support for Telegram notifications (#1308)
-* Webhook url as secret support for Discord, Slack and Teams notifications (#1302)
-* Enhance error message for JSON decode response issues for Gotify, ntfy and RocketChat (#1309)
-* Fix TLS configuration handling for Nomad provider (#1178)
-* Go 1.23 (#1286)
-* Alpine Linux 3.21 (#1286)
-* Switch to github.com/containerd/platforms v0.2.1 (#1287)
-* Switch to github.com/rabbitmq/amqp091-go v1.10.0 (#1288)
-* Bump dario.cat/mergo to 1.0.1 (#1301)
-* Bump github.com/alecthomas/kong from 0.9.0 to 1.6.0 (#1298)
-* Bump github.com/containers/image/v5 to 5.33.0 (#1274 #1284)
-* Bump github.com/distribution/reference from 0.5.0 to 0.6.0 (#1183)
-* Bump github.com/docker/docker to 27.3.1+incompatible (#1181 #1275 #1291)
-* Bump github.com/eclipse/paho.mqtt.golang to 1.5.0 (#1299)
-* Bump github.com/go-playground/validator/v10 to 10.23.0 (#1179 #1191 #1297)
-* Bump github.com/gregdel/pushover to 1.3.1 (#1164)
-* Bump github.com/jedib0t/go-pretty/v6 to 6.6.5 (#1167 #1300)
-* Bump github.com/microcosm-cc/bluemonday to 1.0.27 (#1294)
-* Bump github.com/moby/buildkit to 0.17.3 (#1160 #1312)
-* Bump github.com/panjf2000/ants/v2 to 2.10.0 (#1198)
-* Bump github.com/PaulSonOfLars/gotgbot/v2 to 2.0.0-rc.30 (#1185 #1278)
-* Bump github.com/rs/zerolog to 1.33.0 (#1186)
-* Bump github.com/stretchr/testify to 1.10.0 (#1295)
-* Bump go.etcd.io/bbolt to 1.3.11 (#1187 #1292)
-* Bump golang.org/x/crypto to 0.31.0 (#1271)
-* Bump golang.org/x/mod to 0.22.0 (#1188 #1296)
-* Bump golang.org/x/net to 0.23.0 (#1157)
-* Bump golang.org/x/sys to 0.25.0 (#1184 #1240)
-* Bump google.golang.org/grpc to 1.67.0 (#1171 #1293)
-* Bump google.golang.org/grpc/cmd/protoc-gen-go-grpc to 1.5.1 (#1224)
-* Bump google.golang.org/protobuf to 1.35.2 (#1277)
-* Bump k8s.io/client-go to 0.32.0 (#1280)
+* Topics support for Telegram notifications by @crazy-max in #1308
+* Webhook url as secret support for Discord, Slack and Teams notifications by @crazy-max in #1302
+* Enhance error message for JSON decode response issues for Gotify, ntfy and RocketChat by @crazy-max in #1309
+* Fix TLS configuration handling for Nomad provider by @IamTheFij in #1178
+* Go 1.23 by @crazy-max in #1286
+* Alpine Linux 3.21 by @crazy-max in #1286
+* Switch to github.com/containerd/platforms v0.2.1 by @crazy-max in #1287
+* Switch to github.com/rabbitmq/amqp091-go v1.10.0 by @crazy-max in #1288
+* Bump dario.cat/mergo to 1.0.1 by @crazy-max in #1301
+* Bump github.com/alecthomas/kong to 1.6.0 in #1298
+* Bump github.com/containers/image/v5 to 5.33.0 by @crazy-max in #1274 #1284
+* Bump github.com/distribution/reference to 0.6.0 in #1183
+* Bump github.com/docker/docker to 27.3.1+incompatible by @crazy-max in #1181 #1275 #1291
+* Bump github.com/eclipse/paho.mqtt.golang to 1.5.0 in #1299
+* Bump github.com/go-playground/validator/v10 to 10.23.0 in #1179 #1191 #1297
+* Bump github.com/gregdel/pushover to 1.3.1 in #1164
+* Bump github.com/jedib0t/go-pretty/v6 to 6.6.5 in #1167 #1300
+* Bump github.com/microcosm-cc/bluemonday to 1.0.27 in #1294
+* Bump github.com/moby/buildkit to 0.17.3 by @crazy-max in #1160 #1312
+* Bump github.com/panjf2000/ants/v2 to 2.10.0 in #1198
+* Bump github.com/PaulSonOfLars/gotgbot/v2 to 2.0.0-rc.30 in #1185 #1278
+* Bump github.com/rs/zerolog to 1.33.0 in #1186
+* Bump github.com/stretchr/testify to 1.10.0 in #1295
+* Bump go.etcd.io/bbolt to 1.3.11 by @crazy-max in #1187 #1292
+* Bump golang.org/x/crypto to 0.31.0 in #1271
+* Bump golang.org/x/mod to 0.22.0 in #1188 #1296
+* Bump golang.org/x/net to 0.23.0 in #1157
+* Bump golang.org/x/sys to 0.25.0 in #1184 #1240
+* Bump google.golang.org/grpc to 1.67.0 by @crazy-max in #1171 #1293
+* Bump google.golang.org/grpc/cmd/protoc-gen-go-grpc to 1.5.1 in #1224
+* Bump google.golang.org/protobuf to 1.35.2 in #1277
+* Bump k8s.io/client-go to 0.32.0 in #1280
 
 ## 4.28.0 (2024/04/06)
 
-* Add `tzdata` package to Docker image (#1144)
-* Alpine Linux 3.19 (#1140)
-* Bump github.com/jedib0t/go-pretty/v6 to 6.5.6 (#1137)
-* Bump github.com/panjf2000/ants/v2 to 2.9.1 (#1139)
-* Bump golang.org/x/mod to 0.17.0 (#1143)
-* Bump golang.org/x/sys to 0.19.0 (#1142)
-* Bump google.golang.org/grpc to 1.63.0 (#1141)
+* Add `tzdata` package to Docker image by @crazy-max in #1144
+* Alpine Linux 3.19 by @crazy-max in #1140
+* Bump github.com/jedib0t/go-pretty/v6 to 6.5.6 in #1137
+* Bump github.com/panjf2000/ants/v2 to 2.9.1 in #1139
+* Bump golang.org/x/mod to 0.17.0 in #1143
+* Bump golang.org/x/sys to 0.19.0 in #1142
+* Bump google.golang.org/grpc to 1.63.0 in #1141
 
 ## 4.27.0 (2024/03/23)
 
-* Sound option support for pushover (#996)
-* Fix NTFY markdown (#1025)
-* Fix global defaults for file provider (#1063)
-* Switch to `github.com/PaulSonOfLars/gotgbot/v2` for Telegram API client (#1135)
-* Go 1.21 (#1026 #1050 #1058)
-* Generate sbom and provenance (#1116)
-* Bump github.com/alecthomas/kong to 0.9.0 (#1041 #1118)
-* Bump github.com/containerd/containerd to 1.7.14 (#1047 #1124)
-* Bump github.com/containers/image/v5 to 5.30.0 (#1029 #1112)
-* Bump github.com/docker/distribution to 2.8.3+incompatible (#991)
-* Bump github.com/docker/docker to 25.0.5+incompatible (#1120 #1134)
-* Bump github.com/go-playground/validator/v10 to 10.19.0 (#1020 #1109)
-* Bump github.com/hashicorp/nomad/api to 1.7.2 (#1049)
-* Bump github.com/jedib0t/go-pretty/v6 to 6.5.5 (#1012 #1083 #1126)
-* Bump github.com/microcosm-cc/bluemonday to 1.0.26 (#1042)
-* Bump github.com/moby/buildkit to 0.13.1 (#1043 #1111 #1117 #1128)
-* Bump github.com/opencontainers/image-spec to 1.1.0 (#1100)
-* Bump github.com/panjf2000/ants/v2 to 2.9.0 (#1046)
-* Bump github.com/rs/zerolog to 1.32.0 (#989 #1121)
-* Bump go.etcd.io/bbolt to 1.3.9 (#1044 #1106)
-* Bump golang.org/x/crypto to 0.17.0 (#1060)
-* Bump golang.org/x/mod to 0.16.0 (#1021 #1110)
-* Bump golang.org/x/net to 0.17.0 (#1002)
-* Bump golang.org/x/sys to 0.17.0 (#1035 #1092)
-* Bump google.golang.org/grpc to 1.62.1 (#1048 #1061 #1113)
-* Bump google.golang.org/protobuf to 1.33.0 (#1064 #1119)
-* Bump k8s.io/client-go to 0.29.3 (#1045 #1051 #1098 #1127)
+* Sound option support for pushover by @szerencl in #996
+* Fix NTFY markdown by @stecydube in #1025
+* Fix global defaults for file provider by @adamantike in #1063
+* Switch to `github.com/PaulSonOfLars/gotgbot/v2` for Telegram API client by @jon4hz in #1135
+* Go 1.21 by @IamTheFij, @crazy-max in #1026 #1050 #1058
+* Generate sbom and provenance by @crazy-max in #1116
+* Bump github.com/alecthomas/kong to 0.9.0 in #1041 #1118
+* Bump github.com/containerd/containerd to 1.7.14 in #1047 #1124
+* Bump github.com/containers/image/v5 to 5.30.0 in #1029 #1112
+* Bump github.com/docker/distribution to 2.8.3+incompatible in #991
+* Bump github.com/docker/docker to 25.0.5+incompatible by @crazy-max in #1120 #1134
+* Bump github.com/go-playground/validator/v10 to 10.19.0 in #1020 #1109
+* Bump github.com/hashicorp/nomad/api to 1.7.2 by @IamTheFij in #1049
+* Bump github.com/jedib0t/go-pretty/v6 to 6.5.5 in #1012 #1083 #1126
+* Bump github.com/microcosm-cc/bluemonday to 1.0.26 in #1042
+* Bump github.com/moby/buildkit to 0.13.1 by @crazy-max in #1043 #1111 #1117 #1128
+* Bump github.com/opencontainers/image-spec to 1.1.0 in #1100
+* Bump github.com/panjf2000/ants/v2 to 2.9.0 in #1046
+* Bump github.com/rs/zerolog to 1.32.0 in #989 #1121
+* Bump go.etcd.io/bbolt to 1.3.9 in #1044 #1106
+* Bump golang.org/x/crypto to 0.17.0 in #1060
+* Bump golang.org/x/mod to 0.16.0 in #1021 #1110
+* Bump golang.org/x/net to 0.17.0 in #1002
+* Bump golang.org/x/sys to 0.17.0 in #1035 #1092
+* Bump google.golang.org/grpc to 1.62.1 in #1048 #1061 #1113
+* Bump google.golang.org/protobuf to 1.33.0 in #1064 #1119
+* Bump k8s.io/client-go to 0.29.3 in #1045 #1051 #1098 #1127
 
 ## 4.26.0 (2023/09/23)
 
-* Global `defaults` support for image configuration (#887 #981 #982)
-* `image:tag@digest` format support (#915)
-* Handle analysis of images with tag and digest (#968)
-* Fix latest for `image list` command (#983)
-* Fix dead link in reporting-issue docs (#963)
-* Alpine Linux 3.18 (#914)
-* Bump github.com/AlecAivazis/survey/v2 to 2.3.7 (#900)
-* Bump github.com/alecthomas/kong to 0.8.0 (#905)
-* Bump github.com/containerd/containerd to 1.7.6 (#954)
-* Bump github.com/containers/image/v5 to 5.26.1 (#911)
-* Bump github.com/docker/docker to 24.0.6+incompatible (#947)
-* Bump github.com/eclipse/paho.mqtt.golang to 1.4.3 (#920)
-* Bump github.com/go-playground/validator/v10 to 10.15.4 (#972)
-* Bump github.com/gregdel/pushover to 1.3.0 (#975)
-* Bump github.com/jedib0t/go-pretty/v6 to 6.4.7 (#971)
-* Bump github.com/microcosm-cc/bluemonday to 1.0.25 (#927)
-* Bump github.com/moby/buildkit to 0.12.2 (#940)
-* Bump github.com/opencontainers/image-spec to 1.1.0-rc5 (#912 #974)
-* Bump github.com/panjf2000/ants/v2 to 2.8.2 (#913 #922 #978)
-* Bump github.com/rs/zerolog to 1.30.0 (#976)
-* Bump github.com/streadway/amqp to 1.1.0 (#904)
-* Bump golang.org/x/mod to 0.12.0 (#901 #917)
-* Bump golang.org/x/sys to 0.12.0 (#899 #945)
-* Bump google.golang.org/grpc to 1.58.2 (#906 #961 #980)
-* Bump google.golang.org/protobuf to 1.31.0 (#908)
-* Bump k8s.io/client-go to 0.28.2 (#960)
+* Global `defaults` support for image configuration by @IamTheFij, @crazy-max in #887 #981 #982
+* `image:tag@digest` format support by @crazy-max in #915
+* Handle analysis of images with tag and digest by @crazy-max in #968
+* Fix latest for `image list` command by @crazy-max in #983
+* Fix dead link in reporting-issue docs by @IamTheFij in #963
+* Alpine Linux 3.18 by @crazy-max in #914
+* Bump github.com/AlecAivazis/survey/v2 to 2.3.7 in #900
+* Bump github.com/alecthomas/kong to 0.8.0 in #905
+* Bump github.com/containerd/containerd to 1.7.6 in #954
+* Bump github.com/containers/image/v5 to 5.26.1 in #911
+* Bump github.com/docker/docker to 24.0.6+incompatible in #947
+* Bump github.com/eclipse/paho.mqtt.golang to 1.4.3 in #920
+* Bump github.com/go-playground/validator/v10 to 10.15.4 in #972
+* Bump github.com/gregdel/pushover to 1.3.0 in #975
+* Bump github.com/jedib0t/go-pretty/v6 to 6.4.7 in #971
+* Bump github.com/microcosm-cc/bluemonday to 1.0.25 in #927
+* Bump github.com/moby/buildkit to 0.12.2 in #940
+* Bump github.com/opencontainers/image-spec to 1.1.0-rc5 in #912 #974
+* Bump github.com/panjf2000/ants/v2 to 2.8.2 in #913 #922 #978
+* Bump github.com/rs/zerolog to 1.30.0 in #976
+* Bump github.com/streadway/amqp to 1.1.0 in #904
+* Bump golang.org/x/mod to 0.12.0 in #901 #917
+* Bump golang.org/x/sys to 0.12.0 in #899 #945
+* Bump google.golang.org/grpc to 1.58.2 in #906 #961 #980
+* Bump google.golang.org/protobuf to 1.31.0 in #908
+* Bump k8s.io/client-go to 0.28.2 in #960
 
 ## 4.25.0 (2023/06/12)
 
-* `runOnStartup` watch option (#895)
-* ntfy notification support (#787)
-* Authentication support for ntfy (#890)
-* Sorting for prefixed semver (#765)
-* Check Nomad group meta tags (#763)
-* Go 1.20 (#858)
-* Bump github.com/docker/docker 24.0.2+incompatible (#851 #883)
-* Bump github.com/containers/image/v5 to 5.25.0 (#772 #791 #796 #855)
-* Bump github.com/containerd/containerd to 1.7.2 (#757 #792 #885)
-* Bump github.com/moby/buildkit to 0.11.6 (#790 #809 #848)
-* Bump github.com/crazy-max/gonfig to 0.7.1 (#865)
-* Bump github.com/crazy-max/gohealthchecks to 0.4.1 (#866)
-* Bump github.com/gregdel/pushover to 1.2.0 (#867)
-* Bump go.etcd.io/bbolt to 1.3.7 (#781)
-* Bump github.com/docker/distribution to 2.8.2+incompatible (#871)
-* Bump github.com/opencontainers/runc to 1.1.5 (#834)
-* Bump github.com/rs/zerolog to 1.29.1 (#777 #854)
-* Bump github.com/panjf2000/ants/v2 to 2.7.5 (#846 #889)
-* Bump github.com/jedib0t/go-pretty/v6 to 6.4.4 (#760 #803)
-* Bump github.com/microcosm-cc/bluemonday to 1.0.24 (#780 #810 #876)
-* Bump github.com/go-playground/validator/v10 to 10.14.10 (#778 #852 #896)
-* Bump github.com/imdario/mergo to 0.3.16 (#830 #898)
-* Bump google.golang.org/grpc to 1.52.0 (#762 #785 #826 #864)
-* Bump google.golang.org/grpc/cmd/protoc-gen-go-grpc to 1.3.0 (#806)
-* Bump google.golang.org/protobuf to 1.30.0 (#818)
-* Bump golang.org/x/mod to 0.10.0 (#786 #808 #837)
-* Bump golang.org/x/net to 0.7.0 (#793)
-* Bump golang.org/x/sys to 0.8.0 (#784 #807 #857)
-* Bump github.com/stretchr/testify to 1.8.4 (#801 #897)
+* `runOnStartup` watch option by @crazy-max in #895
+* ntfy notification support by @blueberryapple in #787
+* Authentication support for ntfy by @crazy-max in #890
+* Sorting for prefixed semver by @IamTheFij in #765
+* Check Nomad group meta tags by @IamTheFij in #763
+* Go 1.20 by @crazy-max in #858
+* Bump github.com/docker/docker 24.0.2+incompatible in #851 #883
+* Bump github.com/containers/image/v5 to 5.25.0 in #772 #791 #796 #855
+* Bump github.com/containerd/containerd to 1.7.2 in #757 #792 #885
+* Bump github.com/moby/buildkit to 0.11.6 in #790 #809 #848
+* Bump github.com/crazy-max/gonfig to 0.7.1 in #865
+* Bump github.com/crazy-max/gohealthchecks to 0.4.1 in #866
+* Bump github.com/gregdel/pushover to 1.2.0 in #867
+* Bump go.etcd.io/bbolt to 1.3.7 in #781
+* Bump github.com/docker/distribution to 2.8.2+incompatible in #871
+* Bump github.com/opencontainers/runc to 1.1.5 in #834
+* Bump github.com/rs/zerolog to 1.29.1 in #777 #854
+* Bump github.com/panjf2000/ants/v2 to 2.7.5 in #846 #889
+* Bump github.com/jedib0t/go-pretty/v6 to 6.4.4 in #760 #803
+* Bump github.com/microcosm-cc/bluemonday to 1.0.24 in #780 #810 #876
+* Bump github.com/go-playground/validator/v10 to 10.14.10 in #778 #852 #896
+* Bump github.com/imdario/mergo to 0.3.16 in #830 #898
+* Bump google.golang.org/grpc to 1.52.0 in #762 #785 #826 #864
+* Bump google.golang.org/grpc/cmd/protoc-gen-go-grpc to 1.3.0 in #806
+* Bump google.golang.org/protobuf to 1.30.0 in #818
+* Bump golang.org/x/mod to 0.10.0 in #786 #808 #837
+* Bump golang.org/x/net to 0.7.0 in #793
+* Bump golang.org/x/sys to 0.8.0 in #784 #807 #857
+* Bump github.com/stretchr/testify to 1.8.4 in #801 #897
 
 ## 4.24.0 (2022/12/29)
 
-* Entry metadata field (#749)
-* Jitter watch option (#746)
-* Allow customizing Signal notification message (#748)
+* Entry metadata field by @crazy-max in #749
+* Jitter watch option by @crazy-max in #746
+* Allow customizing Signal notification message by @crazy-max in #748
 
 ## 4.23.1 (2022/12/28)
 
-* Fix release file extension (#743)
+* Fix release file extension by @suzuki-shunsuke in #743
 
 ## 4.23.0 (2022/12/28)
 
-* Nomad provider (#722 #739 #742)
-* Signal (REST API) notifications support (#650)
-* Fix email notification message template (#740)
-* Fix panics when parsing notification templates (#741)
-* Fix test notification typo (#677)
-* docs: Fix `sort_tags` (#655)
-* docs: List valid log levels (#668)
-* docs: Fix the issues URL (#697)
-* docs: New blog posts from the community (#657)
-* Go 1.19 (#701)
-* Alpine Linux 3.17 (#735)
-* Fix proto gen (#720)
-* Enhance workflow (#706)
-* Use `GITHUB_REF` when tag pushed for versioning (#707)
-* Bump github.com/crazy-max/gonfig from 0.5.0 to 0.6.0 (#651)
-* Bump github.com/containerd/containerd from 1.6.6 to 1.6.14 (#669 #719 #732)
-* Bump github.com/rs/zerolog from 1.27.0 to 1.28.0 (#676)
-* Bump github.com/AlecAivazis/survey/v2 from 2.3.5 to 2.3.6 (#686)
-* Bump github.com/docker/go-units from 0.4.0 to 0.5.0 (#678)
-* Bump github.com/tidwall/pretty from 1.2.0 to 1.2.1 (#698)
-* Bump github.com/go-playground/validator/v10 from 10.11.0 to 10.11.1 (#699)
-* Bump github.com/microcosm-cc/bluemonday from 1.0.19 to 1.0.21 (#695)
-* Bump github.com/jedib0t/go-pretty/v6 from 6.3.5 to 6.4.3 (#694 #715 #724)
-* Bump google.golang.org/protobuf from 1.28.0 to 1.28.1 (#661)
-* Bump github.com/containers/image/v5 from 5.21.1 to 5.23.1 (#692 #716)
-* Bump google.golang.org/grpc from 1.48.0 to 1.51.0 (#696 #721)
-* Bump k8s.io/client-go from 0.24.3 to 0.25.4 (#689 #717)
-* Bump github.com/pkg/profile from 1.6.0 to 1.7.0 (#705)
-* Bump github.com/alecthomas/kong from 0.6.1 to 0.7.1 (#718)
-* Bump github.com/eclipse/paho.mqtt.golang from 1.4.1 to 1.4.2 (#711)
-* Bump github.com/panjf2000/ants/v2 from 2.5.0 to 2.7.1 (#709 #733)
-* Bump github.com/stretchr/testify from 1.8.0 to 1.8.1 (#708)
-* Bump github.com/opencontainers/image-spec from 1.1.0-rc1 to 1.1.0-rc2 (#702)
-* Bump golang.org/x/mod to 0.7.0 (#736)
-* Bump golang.org/x/sys to 0.3.0 (#737)
-* Bump github.com/moby/buildkit to 0.10.6 (#738)
+* Nomad provider by @IamTheFij, @crazy-max in #722 #739 #742
+* Signal (REST API) notifications support by @MrRagga- in #650
+* Fix email notification message template by @crazy-max in #740
+* Fix panics when parsing notification templates by @crazy-max in #741
+* Fix test notification typo by @vilm3r in #677
+* docs: Fix `sort_tags` by @hatamiarash7 in #655
+* docs: List valid log levels by @sliekens in #668
+* docs: Fix the issues URL by @DougEdey in #697
+* docs: New blog posts from the community by @crazy-max in #657
+* Go 1.19 by @crazy-max in #701
+* Alpine Linux 3.17 by @crazy-max in #735
+* Fix proto gen by @crazy-max in #720
+* Enhance workflow by @crazy-max in #706
+* Use `GITHUB_REF` when tag pushed for versioning by @crazy-max in #707
+* Bump github.com/crazy-max/gonfig to 0.6.0 in #651
+* Bump github.com/containerd/containerd to 1.6.14 in #669 #719 #732
+* Bump github.com/rs/zerolog to 1.28.0 in #676
+* Bump github.com/AlecAivazis/survey/v2 to 2.3.6 in #686
+* Bump github.com/docker/go-units to 0.5.0 in #678
+* Bump github.com/tidwall/pretty to 1.2.1 in #698
+* Bump github.com/go-playground/validator/v10 to 10.11.1 in #699
+* Bump github.com/microcosm-cc/bluemonday to 1.0.21 in #695
+* Bump github.com/jedib0t/go-pretty/v6 to 6.4.3 in #694 #715 #724
+* Bump google.golang.org/protobuf to 1.28.1 in #661
+* Bump github.com/containers/image/v5 to 5.23.1 in #692 #716
+* Bump google.golang.org/grpc to 1.51.0 in #696 #721
+* Bump k8s.io/client-go to 0.25.4 in #689 #717
+* Bump github.com/pkg/profile to 1.7.0 in #705
+* Bump github.com/alecthomas/kong to 0.7.1 in #718
+* Bump github.com/eclipse/paho.mqtt.golang to 1.4.2 in #711
+* Bump github.com/panjf2000/ants/v2 to 2.7.1 in #709 #733
+* Bump github.com/stretchr/testify to 1.8.1 in #708
+* Bump github.com/opencontainers/image-spec to 1.1.0-rc2 in #702
+* Bump golang.org/x/mod to 0.7.0 by @crazy-max in #736
+* Bump golang.org/x/sys to 0.3.0 by @crazy-max in #737
+* Bump github.com/moby/buildkit to 0.10.6 by @crazy-max in #738
 
 ## 4.22.0 (2022/07/17)
 
-* Allow customizing the hub link (#648)
-* Use OCI image url label to override hub link (#646)
-* Tags sorting support (#645)
-* Alpine Linux 3.16 (#647)
-* Go 1.18 (#592)
-* MkDocs Material 8.3.9 (#644)
-* Explain roles required for rocketchat notification (#553)
-* Bump github.com/AlecAivazis/survey/v2 from 2.3.2 to 2.3.5 (#585 #625)
-* Bump github.com/alecthomas/kong from 0.3.0 to 0.6.1 (#549 #558 #576 #630)
-* Bump github.com/containerd/containerd from 1.5.9 to 1.6.0 (#557)
-* Bump github.com/containers/image/v5 from 5.19.0 to 5.21.1 (#552 #588 #603)
-* Bump github.com/docker/docker from 20.10.12 to 20.10.3-0.20220414164044-61404de7df1a (#575)
-* Bump github.com/eclipse/paho.mqtt.golang from 1.3.5 to 1.4.1 (#623)
-* Bump github.com/go-playground/validator/v10 from 10.10.0 to 10.11.0 (#568 #602)
-* Bump github.com/imdario/mergo from 0.3.12 to 0.3.13 (#617)
-* Bump github.com/jedib0t/go-pretty/v6 from 6.2.5 to 6.3.5 (#555 #584 #595 #642)
-* Bump github.com/microcosm-cc/bluemonday from 1.0.17 to 1.0.19 (#554 #636)
-* Bump github.com/moby/buildkit from 0.9.3 to 0.10.1-0.20220712094726-874eef9b70db (#578 #590 #610 #643)
-* Bump github.com/panjf2000/ants/v2 from 2.4.7 to 2.5.0 (#563 #611)
-* Bump github.com/rs/zerolog from 1.26.1 to 1.27.0 (#626)
-* Bump github.com/stretchr/testify from 1.7.1 to 1.8.0 (#635)
-* Bump google.golang.org/grpc from 1.45.0 to 1.48.0 (#615 #639)
-* Bump google.golang.org/protobuf from 1.27.1 to 1.28.0 (#582)
-* Bump k8s.io/client-go from 0.22.5 to 0.24.3 (#561 #580 #604 #640)
+* Allow customizing the hub link by @crazy-max in #648
+* Use OCI image url label to override hub link by @crazy-max in #646
+* Tags sorting support by @crazy-max in #645
+* Alpine Linux 3.16 by @crazy-max in #647
+* Go 1.18 by @crazy-max in #592
+* MkDocs Material 8.3.9 by @crazy-max in #644
+* Explain roles required for rocketchat notification by @hofbi in #553
+* Bump github.com/AlecAivazis/survey/v2 to 2.3.5 in #585 #625
+* Bump github.com/alecthomas/kong to 0.6.1 in #549 #558 #576 #630
+* Bump github.com/containerd/containerd to 1.6.0 in #557
+* Bump github.com/containers/image/v5 to 5.21.1 in #552 #588 #603
+* Bump github.com/docker/docker to 20.10.3-0.20220414164044-61404de7df1a in #575
+* Bump github.com/eclipse/paho.mqtt.golang to 1.4.1 in #623
+* Bump github.com/go-playground/validator/v10 to 10.11.0 in #568 #602
+* Bump github.com/imdario/mergo to 0.3.13 in #617
+* Bump github.com/jedib0t/go-pretty/v6 to 6.3.5 in #555 #584 #595 #642
+* Bump github.com/microcosm-cc/bluemonday to 1.0.19 in #554 #636
+* Bump github.com/moby/buildkit to 0.10.1-0.20220712094726-874eef9b70db by @crazy-max in #578 #590 #610 #643
+* Bump github.com/panjf2000/ants/v2 to 2.5.0 in #563 #611
+* Bump github.com/rs/zerolog to 1.27.0 in #626
+* Bump github.com/stretchr/testify to 1.8.0 in #635
+* Bump google.golang.org/grpc to 1.48.0 in #615 #639
+* Bump google.golang.org/protobuf to 1.28.0 in #582
+* Bump k8s.io/client-go to 0.24.3 in #561 #580 #604 #640
 
 ## 4.21.0 (2022/01/26)
 
-* Add `image prune` command (#519)
-* Fix matrix login scheme (#487)
-* Move `syscall` to `golang.org/x/sys` (#525)
-* Move from `io/ioutil` to `os` package (#524)
+* Add `image prune` command by @crazy-max in #519
+* Fix matrix login scheme by @crazy-max in #487
+* Move `syscall` to `golang.org/x/sys` by @crazy-max in #525
+* Move from `io/ioutil` to `os` package by @crazy-max in #524
 * Fix notif template in docs
-* Enhance dockerfiles (#523)
-* Add binary bake target (#517)
-* MkDocs Material 8.1.8 (#520 #548)
-* Alpine Linux 3.15 (#527)
-* goreleaser-xx 1.2.5 (#539)
-* Bump github.com/alecthomas/kong from 0.2.17 to 0.3.0 (#507 #537)
-* Bump github.com/containerd/containerd from 1.5.5 to 1.5.8 (#494 #496 #509)
-* Bump github.com/containers/image/v5 from 5.16.0 to 5.19.0 (#498 #536 #546)
-* Bump github.com/docker/docker from 20.10.8+incompatible to 20.10.12+incompatible (#500 #510 #531)
-* Bump github.com/go-playground/validator/v10 from 10.9.0 to 10.10.0 (#538)
-* Bump github.com/jedib0t/go-pretty/v6 from 6.2.4 to 6.2.5 (#543)
-* Bump github.com/microcosm-cc/bluemonday from 1.0.15 to 1.0.17 (#499 #535)
-* Bump github.com/moby/buildkit from 0.9.0 to 0.9.3 (#495 #506 #512)
-* Bump github.com/opencontainers/image-spec to v1.0.2-0.20211117181255-693428a734f5 (#513)
-* Bump github.com/panjf2000/ants/v2 from 2.4.6 to 2.4.7 (#532)
-* Bump github.com/rs/zerolog from 1.24.0 to 1.26.1 (#485 #502 #534)
-* Bump google.golang.org/grpc from 1.40.0 to 1.44.0 (#492 #505 #529 #545)
-* Bump google.golang.org/grpc/cmd/protoc-gen-go-grpc from 1.1.0 to 1.2.0 (#533)
-* Bump k8s.io/client-go from 0.22.1 to 0.22.4 (#490 #511)
+* Enhance dockerfiles by @crazy-max in #523
+* Add binary bake target by @crazy-max in #517
+* MkDocs Material 8.1.8 by @crazy-max in #520 #548
+* Alpine Linux 3.15 by @crazy-max in #527
+* goreleaser-xx 1.2.5 by @crazy-max in #539
+* Bump github.com/alecthomas/kong to 0.3.0 in #507 #537
+* Bump github.com/containerd/containerd to 1.5.8 in #494 #496 #509
+* Bump github.com/containers/image/v5 to 5.19.0 in #498 #536 #546
+* Bump github.com/docker/docker to 20.10.12+incompatible in #500 #510 #531
+* Bump github.com/go-playground/validator/v10 to 10.10.0 in #538
+* Bump github.com/jedib0t/go-pretty/v6 to 6.2.5 in #543
+* Bump github.com/microcosm-cc/bluemonday to 1.0.17 in #499 #535
+* Bump github.com/moby/buildkit to 0.9.3 in #495 #506 #512
+* Bump github.com/opencontainers/image-spec to v1.0.2-0.20211117181255-693428a734f5 by @crazy-max in #513
+* Bump github.com/panjf2000/ants/v2 to 2.4.7 in #532
+* Bump github.com/rs/zerolog to 1.26.1 in #485 #502 #534
+* Bump google.golang.org/grpc to 1.44.0 in #492 #505 #529 #545
+* Bump google.golang.org/grpc/cmd/protoc-gen-go-grpc to 1.2.0 in #533
+* Bump k8s.io/client-go to 0.22.4 in #490 #511
 
 ## 4.20.1 (2021/09/06)
 
-* Fix notification title (#483)
+* Fix notification title by @crazy-max in #483
 
 ## 4.20.0 (2021/09/05)
 
-* Option to render fields (#480)
-* Allow choosing status to be notified (#475)
-* Enhance notif wording (#467)
-* Wrong remaining time displayed (#469)
-* Allow multi recipients for email notifier (#463)
-* Provide mutable tags for Diun image (#462)
-* Fix Dockerfile parser and add tests (#459)
-* Add e2e tests (#471)
-* Use args in kubernetes documentation example (#424)
-* Fix j2 variable in docs (#422)
-* Note to customize the hostname (#465)
-* Go 1.17 (#458)
-* Add `windows/arm64` artifact (#472)
-* Add `linux/riscv64` artifact (#427)
-* Alpine Linux 3.14 (#426)
-* MkDocs Material 7.2.6 (#428 #482)
-* Protoc 3.17.3 (#461)
-* Bump github.com/rs/zerolog from 1.23.0 to 1.24.0 (#477)
-* Bump github.com/crazy-max/gonfig from 0.4.0 to 0.5.0 (#474)
-* Bump github.com/gregdel/pushover to 1.1.0 (#470)
-* Bump github.com/streadway/amqp to 1.0.0 (#470)
-* Bump github.com/containers/image/v5 from 5.13.2 to 5.16.0 (#460 #476)
-* Bump k8s.io/client-go from 0.21.2 to 0.22.1 (#466)
-* Bump github.com/docker/docker from 20.10.7 to 20.10.8 (#451)
-* Bump github.com/moby/buildkit from 0.8.3 to 0.9.0 (#437)
-* Bump github.com/containerd/containerd from 1.5.2 to 1.5.5 (#433 #440 #447)
-* Bump github.com/microcosm-cc/bluemonday from 1.0.14 to 1.0.15 (#430)
-* Bump github.com/go-playground/validator/v10 from 10.6.1 to 10.9.0 (#429 #445 #455)
-* Bump github.com/jedib0t/go-pretty/v6 from 6.2.2 to 6.2.4 (#432)
-* Bump google.golang.org/grpc from 1.38.0 to 1.40.0 (#421 #453 #456)
-* Bump google.golang.org/protobuf from 1.26.0 to 1.27.1 (#420)
-* Bump codecov/codecov-action from 1 to 2
+* Option to render fields by @crazy-max in #480
+* Allow choosing status to be notified by @crazy-max in #475
+* Enhance notif wording by @crazy-max in #467
+* Wrong remaining time displayed by @crazy-max in #469
+* Allow multi recipients for email notifier by @crazy-max in #463
+* Provide mutable tags for Diun image by @crazy-max in #462
+* Fix Dockerfile parser and add tests by @crazy-max in #459
+* Add e2e tests by @crazy-max in #471
+* Use args in kubernetes documentation example by @paddatrapper in #424
+* Fix j2 variable in docs by @crazy-max in #422
+* Note to customize the hostname by @crazy-max in #465
+* Go 1.17 by @crazy-max in #458
+* Add `windows/arm64` artifact by @crazy-max in #472
+* Add `linux/riscv64` artifact by @crazy-max in #427
+* Alpine Linux 3.14 by @crazy-max in #426
+* MkDocs Material 7.2.6 by @crazy-max in #428 #482
+* Protoc 3.17.3 by @crazy-max in #461
+* Bump github.com/rs/zerolog to 1.24.0 in #477
+* Bump github.com/crazy-max/gonfig to 0.5.0 in #474
+* Bump github.com/gregdel/pushover to 1.1.0 by @crazy-max in #470
+* Bump github.com/streadway/amqp to 1.0.0 by @crazy-max in #470
+* Bump github.com/containers/image/v5 to 5.16.0 in #460 #476
+* Bump k8s.io/client-go to 0.22.1 in #466
+* Bump github.com/docker/docker to 20.10.8 in #451
+* Bump github.com/moby/buildkit to 0.9.0 in #437
+* Bump github.com/containerd/containerd to 1.5.5 in #433 #440 #447
+* Bump github.com/microcosm-cc/bluemonday to 1.0.15 in #430
+* Bump github.com/go-playground/validator/v10 to 10.9.0 in #429 #445 #455
+* Bump github.com/jedib0t/go-pretty/v6 to 6.2.4 in #432
+* Bump google.golang.org/grpc to 1.40.0 in #421 #453 #456
+* Bump google.golang.org/protobuf to 1.27.1 in #420
+* Bump codecov/codecov-action to 2
 
 ## 4.19.0 (2021/06/26)
 
-* Allow customizing notification message (#415)
-* Bump github.com/panjf2000/ants/v2 from 2.4.5 to 2.4.6 (#416)
-* Bump k8s.io/client-go from 0.21.1 to 0.21.2 (#414)
-* Bump github.com/microcosm-cc/bluemonday from 1.0.13 to 1.0.14 (#413)
-* Bump github.com/containers/image/v5 from 5.13.1 to 5.13.2 (#412)
+* Allow customizing notification message by @crazy-max in #415
+* Bump github.com/panjf2000/ants/v2 to 2.4.6 in #416
+* Bump k8s.io/client-go to 0.21.2 in #414
+* Bump github.com/microcosm-cc/bluemonday to 1.0.14 in #413
+* Bump github.com/containers/image/v5 to 5.13.2 in #412
 
 ## 4.18.0 (2021/06/18)
 
-* Handle registry auth config (#411)
-* Bump k8s.io/client-go from 0.20.6 to 0.21.1 (#381)
-* Bump github.com/containers/image/v5 from 5.12.0 to 5.13.1 (#409)
-* Avoid notification for unupdated image (#406)
-* Use `openssl` pkg (#407)
-* Bump github.com/rs/zerolog from 1.22.0 to 1.23.0 (#405)
-* Bump google.golang.org/grpc from 1.37.0 to 1.38.0 (#389)
-* Bump github.com/microcosm-cc/bluemonday from 1.0.9 to 1.0.13 (#403 #410)
-* Bumps github.com/docker/docker from 20.10.6+incompatible to 20.10.7+incompatible (#397)
-* Bump github.com/jedib0t/go-pretty/v6 from 6.2.1 to 6.2.2 (#388)
-* Bump go.etcd.io/bbolt from 1.3.5 to 1.3.6 (#394)
-* Bump github.com/eclipse/paho.mqtt.golang from 1.3.4 to 1.3.5 (#400)
-* Bump github.com/alecthomas/kong from 0.2.16 to 0.2.17 (#401)
-* Bump github.com/tidwall/pretty from 1.1.0 to 1.2.0 (#390 #402)
-* Set `cacheonly` output for validators (#395)
-* Define serve command (#393)
-* Save raw manifest in db (#391)
+* Handle registry auth config by @crazy-max in #411
+* Bump k8s.io/client-go to 0.21.1 in #381
+* Bump github.com/containers/image/v5 to 5.13.1 in #409
+* Avoid notification for unupdated image by @crazy-max in #406
+* Use `openssl` pkg by @crazy-max in #407
+* Bump github.com/rs/zerolog to 1.23.0 in #405
+* Bump google.golang.org/grpc to 1.38.0 in #389
+* Bump github.com/microcosm-cc/bluemonday to 1.0.13 in #403 #410
+* Bumps github.com/docker/docker to 20.10.7+incompatible in #397
+* Bump github.com/jedib0t/go-pretty/v6 to 6.2.2 in #388
+* Bump go.etcd.io/bbolt to 1.3.6 in #394
+* Bump github.com/eclipse/paho.mqtt.golang to 1.3.5 in #400
+* Bump github.com/alecthomas/kong to 0.2.17 in #401
+* Bump github.com/tidwall/pretty to 1.2.0 in #390 #402
+* Set `cacheonly` output for validators by @crazy-max in #395
+* Define serve command by @crazy-max in #393
+* Save raw manifest in db by @crazy-max in #391
 
 ## 4.17.0 (2021/05/26)
 
 :warning: See **Migration notes** in the documentation before upgrading.
 
-* Add CLI to interact with Diun through gRPC (#382)
+* Add CLI to interact with Diun through gRPC by @crazy-max in #382
     * Create `image` and `notif` proto services
     * Implement proto definitions
     * New commands `serve`, `image` and `notif`
@@ -386,142 +386,142 @@
     * Compile and validate protos through a dedicated Dockerfile and a bake target    
     * Merge validate and build workflow
     * Add upgrade notes
-* Bump github.com/eclipse/paho.mqtt.golang from 1.3.3 to 1.3.4 (#359)
-* Bump github.com/panjf2000/ants/v2 from 2.4.4 to 2.4.5 (#380)
-* Bump github.com/rs/zerolog from 1.21.0 to 1.22.0 (#379)
-* Bump github.com/go-playground/validator/v10 from 10.5.0 to 10.6.1 (#377)
-* MkDocs Materials 7.1.5 (#386)
-* Add `NO_COLOR` support (#384)
-* Bump github.com/pkg/profile from 1.5.0 to 1.6.0 (#363)
-* Move to docker/metadata-action (#366)
-* Bump github.com/containers/image/v5 from 5.11.1 to 5.12.0 (#360)
-* Bump github.com/containerd/containerd from 1.5.0-beta.4 to 1.5.2 (#353 #361 #362 #383)
-* Add blog posts (#355 #385)
-* Bump github.com/moby/buildkit from 0.8.2 to 0.8.3 (#354)
+* Bump github.com/eclipse/paho.mqtt.golang to 1.3.4 in #359
+* Bump github.com/panjf2000/ants/v2 to 2.4.5 in #380
+* Bump github.com/rs/zerolog to 1.22.0 in #379
+* Bump github.com/go-playground/validator/v10 to 10.6.1 in #377
+* MkDocs Materials 7.1.5 by @crazy-max in #386
+* Add `NO_COLOR` support by @crazy-max in #384
+* Bump github.com/pkg/profile to 1.6.0 in #363
+* Move to docker/metadata-action by @crazy-max in #366
+* Bump github.com/containers/image/v5 to 5.12.0 in #360
+* Bump github.com/containerd/containerd to 1.5.2 by @crazy-max in #353 #361 #362 #383
+* Add blog posts by @crazy-max in #355 #385
+* Bump github.com/moby/buildkit to 0.8.3 in #354
 
 ## 4.16.1 (2021/04/30)
 
-* Fix Swarm Provider (#351)
+* Fix Swarm Provider by @crazy-max in #351
 
 ## 4.16.0 (2021/04/29)
 
-* Dockerfile provider (#329)
-* Note about `watch_repo` setting (#348)
-* Contribute to doc (#347)
-* Update docs for Podman support (#345)
-* Optional profiler volume (#344)
+* Dockerfile provider by @crazy-max in #329
+* Note about `watch_repo` setting by @crazy-max in #348
+* Contribute to doc by @crazy-max in #347
+* Update docs for Podman support by @signed-log in #345
+* Optional profiler volume by @crazy-max in #344
 
 ## 4.15.2 (2021/04/25)
 
-* Make profiler optional (#341)
+* Make profiler optional by @crazy-max in #341
 
 ## 4.15.1 (2021/04/25)
 
-* Fix profiler path (#339)
+* Fix profiler path by @crazy-max in #339
 
 ## 4.15.0 (2021/04/25)
 
-* Add `darwin/arm64` artifact (#338)
-* MkDocs Materials 7.1.3 (#337)
-* Add profiler flag (#336)
-* Handle digest based image reference (#335)
-* Bump github.com/docker/docker from 20.10.5+incompatible to 20.10.6+incompatible (#324)
-* Bump github.com/containers/image/v5 from 5.10.5 to 5.11.1 (#323 #330)
-* Bump github.com/go-playground/validator/v10 from 10.4.1 to 10.5.0 (#319)
-* Bump github.com/panjf2000/ants/v2 from 2.4.3 to 2.4.4 (#312)
-* Bump github.com/rs/zerolog from 1.20.0 to 1.21.0 (#309)
-* Bump github.com/microcosm-cc/bluemonday from 1.0.4 to 1.0.9 (#311 #321 #325 #333)
-* Bump github.com/eclipse/paho.mqtt.golang from 1.3.2 to 1.3.3 (#316)
-* Deploy docs on workflow dispatch or tag (#305)
+* Add `darwin/arm64` artifact by @crazy-max in #338
+* MkDocs Materials 7.1.3 by @crazy-max in #337
+* Add profiler flag by @crazy-max in #336
+* Handle digest based image reference by @crazy-max in #335
+* Bump github.com/docker/docker to 20.10.6+incompatible in #324
+* Bump github.com/containers/image/v5 to 5.11.1 in #323 #330
+* Bump github.com/go-playground/validator/v10 to 10.5.0 in #319
+* Bump github.com/panjf2000/ants/v2 to 2.4.4 in #312
+* Bump github.com/rs/zerolog to 1.21.0 in #309
+* Bump github.com/microcosm-cc/bluemonday to 1.0.9 in #311 #321 #325 #333
+* Bump github.com/eclipse/paho.mqtt.golang to 1.3.3 in #316
+* Deploy docs on workflow dispatch or tag by @crazy-max in #305
 
 ## 4.14.0 (2021/03/15)
 
-* Bump k8s.io/client-go from 0.19.4 to 0.20.4 (#280)
-* Docker client 20.10.5 (#303)
-* Allow telegram chat IDs as file (#301)
-* Go 1.16 (#302)
+* Bump k8s.io/client-go to 0.20.4 in #280
+* Docker client 20.10.5 by @crazy-max in #303
+* Allow telegram chat IDs as file by @crazy-max in #301
+* Go 1.16 by @crazy-max in #302
 * Handle git ref for artifact target
-* Bump github.com/imdario/mergo from 0.3.11 to 0.3.12 (#298)
-* Bump github.com/crazy-max/gohealthchecks from 0.2.0 to 0.3.0 (#296)
-* Bump github.com/alecthomas/kong from 0.2.15 to 0.2.16 (#295)
-* Allow configuring scheme for MQTT broker (#292)
-* Switch to [goreleaser-xx](https://github.com/crazy-max/goreleaser-xx) (#291)
-* Bump github.com/containers/image/v5 from 5.10.4 to 5.10.5 (#290)
+* Bump github.com/imdario/mergo to 0.3.12 in #298
+* Bump github.com/crazy-max/gohealthchecks to 0.3.0 in #296
+* Bump github.com/alecthomas/kong to 0.2.16 in #295
+* Allow configuring scheme for MQTT broker by @fblackburn1 in #292
+* Switch to [goreleaser-xx](https://github.com/crazy-max/goreleaser-xx) by @crazy-max in #291
+* Bump github.com/containers/image/v5 to 5.10.5 in #290
 
 ## 4.13.0 (2021/03/01)
 
-* Missing token as secret setting for some notifiers (#289)
-* Allow disabling log color output (#288)
-* Bump github.com/containers/image/v5 from 5.10.1 to 5.10.4 (#271 #282 #284)
-* Cleanup workflows (#281 #287)
-* Do not check recipient details for Pushover (#277)
-* MkDocs Materials 6.2.8 (#276)
-* Fix markdown renderer (#275)
-* Add message client for notifiers (#273)
+* Missing token as secret setting for some notifiers by @crazy-max in #289
+* Allow disabling log color output by @crazy-max in #288
+* Bump github.com/containers/image/v5 to 5.10.4 in #271 #282 #284
+* Cleanup workflows by @crazy-max in #281 #287
+* Do not check recipient details for Pushover by @crazy-max in #277
+* MkDocs Materials 6.2.8 by @crazy-max in #276
+* Fix markdown renderer by @crazy-max in #275
+* Add message client for notifiers by @crazy-max in #273
 
 ## 4.12.0 (2021/02/09)
 
-* Use digest as comparison footprint (#269)
-* Bump github.com/alecthomas/kong from 0.2.12 to 0.2.15 (#270)
-* Bump github.com/eclipse/paho.mqtt.golang from 1.3.1 to 1.3.2 (#268)
-* Bump github.com/containers/image/v5 from 5.9.0 to 5.10.1 (#265)
-* Move to [docker/bake-action](https://github.com/docker/bake-action) (#266)
-* Typo in documentation (#258)
+* Use digest as comparison footprint by @crazy-max in #269
+* Bump github.com/alecthomas/kong to 0.2.15 in #270
+* Bump github.com/eclipse/paho.mqtt.golang to 1.3.2 in #268
+* Bump github.com/containers/image/v5 to 5.10.1 in #265
+* Move to [docker/bake-action](https://github.com/docker/bake-action) by @crazy-max in #266
+* Typo in documentation by @TheCatLady in #258
 * Log image validation
 
 ## 4.11.0 (2021/01/04)
 
-* Fix DB migration (#255)
-* Add Pushover notification (#254)
-* Avoid duplicated notifications with Kubernetes DaemonSet (#252)
-* Make scheduler optional (#251)
-* Bump github.com/eclipse/paho.mqtt.golang from 1.3.0 to 1.3.1 (#249)
-* Handle exclusions as a distinct status (#248)
+* Fix DB migration by @crazy-max in #255
+* Add Pushover notification by @crazy-max in #254
+* Avoid duplicated notifications with Kubernetes DaemonSet by @crazy-max in #252
+* Make scheduler optional by @crazy-max in #251
+* Bump github.com/eclipse/paho.mqtt.golang to 1.3.1 in #249
+* Handle exclusions as a distinct status by @crazy-max in #248
 
 ## 4.10.0 (2020/12/26)
 
-* Refactor CI and dev workflow with buildx bake (#247)
+* Refactor CI and dev workflow with buildx bake by @crazy-max in #247
     * Upload artifacts
     * Add `image-local` target
     * Single job for artifacts and image
     * Add `armv5` artifact
-* MQTT Reconnection Log Spam (#241)
-* Add Docker + File providers user guide (#239)
-* Bump github.com/alecthomas/kong from 0.2.11 to 0.2.12 (#231)
-* Bump github.com/eclipse/paho.mqtt.golang from 1.2.0 to 1.3.0 (#235)
-* Bump github.com/containers/image/v5 from 5.8.1 to 5.9.0 (#236)
-* Bump gopkg.in/yaml.v2 from 2.3.0 to 2.4.0 (#228)
-* Bump github.com/containers/image/v5 from 5.8.0 to 5.8.1 (#226)
+* MQTT Reconnection Log Spam by @aschoelzhorn in #241
+* Add Docker + File providers user guide by @crazy-max in #239
+* Bump github.com/alecthomas/kong to 0.2.12 in #231
+* Bump github.com/eclipse/paho.mqtt.golang to 1.3.0 in #235
+* Bump github.com/containers/image/v5 to 5.9.0 in #236
+* Bump gopkg.in/yaml.v2 to 2.4.0 in #228
+* Bump github.com/containers/image/v5 to 5.8.1 in #226
 
 ## 4.9.0 (2020/11/16)
 
 * Fix duplicated notifications
 * Remove support for `freebsd/*` (moby/moby#38818)
 * Add support for `linux/ppc64le` and `linux/s390x` (binary)
-* Bump k8s.io/client-go from 0.19.3 to 0.19.4 (#224)
+* Bump k8s.io/client-go to 0.19.4 in #224
 * Bump github.com/containers/image/v5 to 5.8.0
 
 ## 4.8.1 (2020/11/14)
 
-* Fix registry timeout context (#221)
+* Fix registry timeout context in #221
 * Image closer not required while fetching tags
 
 ## 4.8.0 (2020/11/13)
 
-* Go 1.15 (#218)
+* Go 1.15 by @crazy-max in #218
 * Remove `linux/s390x` platform support (for now)
-* Check digest from HEAD request (#217)
+* Check digest from HEAD request by @crazy-max in #217
 * Add FAQ note about Docker Hub rate limits
 * Compare digest as watch setting
 * Optimize build time
-* Add hub link for GitHub Container Registry (#211)
+* Add hub link for GitHub Container Registry by @crazy-max in #211
 * Update deps
 
 ## 4.7.0 (2020/11/02)
 
-* Add MQTT notification (#192)
+* Add MQTT notification by @aschoelzhorn in #192
 * Docker image also available on [GitHub Container Registry](https://github.com/users/crazy-max/packages/container/package/diun)
-* Use zoneinfo from Go (#202)
+* Use zoneinfo from Go in #202
 * Remove `--timezone` flag
 * Use Docker meta action to handle tags and labels
 * Update deps
@@ -529,34 +529,34 @@
 ## 4.6.1 (2020/10/22)
 
 * Typos in documentation
-* Bump docker/login-action from v1.4.1 to v1.6.0 (#198)
-* Bump k8s.io/client-go from 0.19.2 to 0.19.3 (#199)
-* Bump codecov/codecov-action from v1.0.13 to v1.0.14 (#195)
-* Bump github.com/go-playground/validator/v10 from 10.4.0 to 10.4.1 (#197)
-* Bump github.com/panjf2000/ants/v2 from 2.4.2 to 2.4.3 (#196)
+* Bump docker/login-action to v1.6.0 in #198
+* Bump k8s.io/client-go to 0.19.3 in #199
+* Bump codecov/codecov-action to v1.0.14 in #195
+* Bump github.com/go-playground/validator/v10 to 10.4.1 in #197
+* Bump github.com/panjf2000/ants/v2 to 2.4.3 in #196
 
 ## 4.6.0 (2020/10/13)
 
-* Add support for [Healthchecks](https://healthchecks.io/) to monitor Diun watcher (#78)
-* Add option to mention specific users or roles for Discord notifier (#188)
+* Add support for [Healthchecks](https://healthchecks.io/) to monitor Diun watcher in #78
+* Add option to mention specific users or roles for Discord notifier in #188
 * Update docker install documentation
-* Add "Too many requests to registry" section in FAQ (#168)
+* Add "Too many requests to registry" section in FAQ in #168
 * Update deps
 * Switch to [Docker actions](https://github.com/docker/build-push-action)
 
 ## 4.5.0 (2020/08/29)
 
-* Allow setting the hostname sent to the SMTP server with the HELO command for mail notification (#165)
-* Fix Telegram notification error (#162)
+* Allow setting the hostname sent to the SMTP server with the HELO command for mail notification in #165
+* Fix Telegram notification error in #162
 
 ## 4.4.1 (2020/08/20)
 
-* Allow using `--test-notif` without providers and DB connection (#157 #150)
+* Allow using `--test-notif` without providers and DB connection in #157 #150
 * Update deps
 
 ## 4.4.0 (2020/08/08)
 
-* Allow customizing message type for Matrix notifications (#143)
+* Allow customizing message type for Matrix notifications in #143
 
 ## 4.3.1 (2020/07/30)
 
@@ -564,11 +564,11 @@
 
 ## 4.3.0 (2020/07/29)
 
-* Add Matrix notification (#124)
+* Add Matrix notification in #124
 
 ## 4.2.0 (2020/07/16)
 
-* Seek configuration file from default places (#107)
+* Seek configuration file from default places in #107
 * Switch to [gonfig](https://github.com/crazy-max/gonfig)
 * Update deps
 
@@ -578,56 +578,56 @@
 
 ## 4.1.0 (2020/06/26)
 
-* Discord notifications (#110 #111)
-* Update migration notes (#107)
-* Logging when configuration file or `DIUN_` env vars not found (#107)
-* Bump github.com/containers/image/v5 from 5.4.4 to 5.5.1 (#96)
+* Discord notifications by @crazy-max in #110 #111
+* Update migration notes in #107
+* Logging when configuration file or `DIUN_` env vars not found in #107
+* Bump github.com/containers/image/v5 to 5.5.1 in #96
 
 ## 4.0.0 (2020/06/22)
 
 :warning: See **Migration notes** in the documentation for breaking changes.
 
-* Display hostname in notifications (#102)
-* Automatically determine registry options based on image name (#103)
-* Docs website with mkdocs (#99)
-* Skip dangling images (#98)
-* More explicit message if manifest not found (#94)
+* Display hostname in notifications in #102
+* Automatically determine registry options based on image name by @crazy-max in #103
+* Docs website with mkdocs in #99
+* Skip dangling images in #98
+* More explicit message if manifest not found in #94
 * Add swarm example
 * Update doc for file and Swarm providers
-* Add Kubernetes provider (#25)
-* Update Teams notification screenshot (#93)
+* Add Kubernetes provider in #25
+* Update Teams notification screenshot by @margaale in #93
 * Send message as markdown for Gotify and Telegram notifiers
-* Add link to respective hub (#40)
-* Configuration transposed into environment variables (#82)
+* Add link to respective hub in #40
+* Configuration transposed into environment variables by @crazy-max in #82
 * Configuration file not required anymore
 * `DIUN_DB` env var renamed `DIUN_DB_PATH`
 * Only accept duration as timeout value (`10` becomes `10s`)
-* Enhanced documentation (#83)
-* Add note about test notifications (#79)
+* Enhanced documentation in #83
+* Add note about test notifications by @Tooa in #79
 * Improve configuration validation
 * Fix telegram init
 * All fields in configuration are now _camelCased_
-* Docker API version negotiation (#29)
-* Add Mattermost compatibility via Slack webhooks (#80)
+* Docker API version negotiation in #29
+* Add Mattermost compatibility via Slack webhooks by @Twilek-de in #80
 * Update deps
 
 ## 3.0.0 (2020/05/27)
 
 :warning: See **Migration notes** in the documentation for breaking changes.
 
-* Add script notification (#53)
-* Add Teams notification (#72)
-* Add `--test-notif` flag (#23)
+* Add script notification in #53
+* Add Teams notification by @margaale in #72
+* Add `--test-notif` flag in #23
 * Allow only one Docker and Swarm provider
 * Remove "enable" setting for notifiers
 * Logging when no image is found
-* Add Amqp notification client (#63)
+* Add Amqp notification client by @margaale in #63
 * Fix default log level
-* Move static to file provider (#71)
-* Reload config on change for file provider (#16)
-* Switch to kong command-line parser (#66)
+* Move static to file provider by @crazy-max in #71
+* Reload config on change for file provider in #16
+* Switch to kong command-line parser by @crazy-max in #66
 * Enhanced Dockerfile
-* Review of platform detection (#57)
+* Review of platform detection in #57
 * Leave default image platform empty for file provider (see FAQ doc)
 * Handle platform variant
 * Add database migration process
@@ -638,26 +638,26 @@
 
 ## 2.6.1 (2020/03/26)
 
-* Downgrade containers/image to 5.2.1 (#54)
+* Downgrade containers/image to 5.2.1 in #54
 
 ## 2.6.0 (2020/03/26)
 
-* Fix service image inspection (#52)
+* Fix service image inspection in #52
 * Docker client v19.03.8
 * Update deps
 
 ## 2.5.0 (2020/03/01)
 
-* Add Rocket.Chat notifier (#44)
+* Add Rocket.Chat notifier by @crazy-max in #44
 
 ## 2.4.0 (2020/02/17)
 
-* Add Gotify notification client (#36)
-* Bump containers/image v5 (#35) 
+* Add Gotify notification client by @crazy-max in #36
+* Bump containers/image v5 by @crazy-max in #35
 
 ## 2.3.0 (2020/01/28)
 
-* Add Telegram notifier (#30)
+* Add Telegram notifier by @DanNixon in #30
 * Docker client struct options
 * Move registry client to a dedicated package
 
@@ -668,12 +668,12 @@
 
 ## 2.2.0 (2019/12/22)
 
-* Add option to skip notification at the very first analysis of an image (#10)
+* Add option to skip notification at the very first analysis of an image in #10
 * Skip analysis of locally built image
 
 ## 2.1.0 (2019/12/17)
 
-* Add Slack notifier (#8)
+* Add Slack notifier in #8
 
 ## 2.0.0 (2019/12/14)
 
@@ -683,8 +683,8 @@
 * Add providers documentation
 * Move image validation and improve job execution
 * Add Swarm provider
-* Add fields to load sensitive values from file (#7)
-* Add Docker provider (#3)
+* Add fields to load sensitive values from file in #7
+* Add Docker provider in #3
 * Docker client v19.03.5
 * Move `image` field to providers layer and rename it `static`
 * Update deps
@@ -716,7 +716,7 @@
 
 * Update deps
 * Display containers/image logs
-* Fix registry options not setted (#5)
+* Fix registry options not setted in #5
 
 ## 1.1.0 (2019/07/24)
 

--- a/README.md
+++ b/README.md
@@ -15,10 +15,17 @@
 
 ## About
 
-**Diun** is a CLI application written in [Go](https://golang.org/)  and delivered as a
-[single executable](https://github.com/crazy-max/diun/releases/latest) (and a
-[Docker image](https://hub.docker.com/r/crazymax/diun/)) to receive notifications when a Docker image is updated on
-a Docker registry.
+**Diun** watches container images and tells you when an update is available.
+It checks registries for new tags or digest changes, so you can track base image
+updates, application releases, and security rebuilds without manually checking
+every repository.
+
+It is built for self-hosted and automated environments where keeping images
+current matters, but silent drift is easy to miss. You can run Diun as a single
+[executable](https://github.com/crazy-max/diun/releases/latest) or as a
+[Docker image](https://hub.docker.com/r/crazymax/diun/), connect it to your
+container platforms and config files, and receive notifications through the
+services you already use.
 
 ![](.res/screenshot.png)
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -7,14 +7,14 @@ to the public under the [project's open source license]([[ config.repo_url ]]/bl
 
 ## Submitting a pull request
 
-1. [Fork]([[ config.repo_url ]]fork) and clone the repository
+1. [Fork]([[ config.repo_url ]]/fork) and clone the repository
 2. Configure and install the dependencies: `go mod download`
 3. Create a new branch: `git checkout -b my-branch-name`
 4. Make your changes
 5. Validate: `docker buildx bake validate`
 6. Test your code: `docker buildx bake test`
 7. Build the project: `docker buildx bake artifact-all image-all`
-8. Push to your fork and [submit a pull request]([[ config.repo_url ]]compare)
+8. Push to your fork and [submit a pull request]([[ config.repo_url ]]/compare)
 9. Pat your self on the back and wait for your pull request to be reviewed and merged.
 
 Here are a few things you can do that will increase the likelihood of your pull request being accepted:

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,27 +16,33 @@
 
 ## What is Diun?
 
-**D**ocker **I**mage **U**pdate **N**otifier is a CLI application written in [Go](https://golang.org/) and delivered as a
-[single executable](https://github.com/crazy-max/diun/releases/latest) (and a [Docker image](install/docker.md))
-to receive notifications when a Docker image is updated on a Docker registry.
+**D**ocker **I**mage **U**pdate **N**otifier helps you keep track of container
+image updates without manually watching registries.
 
-With Go, this can be done with an independent binary distribution across all platforms and architectures that Go supports.
-This support includes Linux, macOS, and Windows, on architectures like amd64, i386, ARM, PowerPC, and others.
+Diun checks your images on a schedule, detects when a tracked tag or digest has
+changed, and notifies you when something new is available. That makes it useful
+for staying on top of upstream base image rebuilds, application releases, and
+other image changes that can otherwise slip by unnoticed.
+
+You can run Diun as a [single executable](https://github.com/crazy-max/diun/releases/latest)
+or as a [Docker image](install/docker.md), point it at the container sources you
+care about, and send notifications to the messaging services your team already
+uses.
 
 ## Features
 
-* Allow watching a Docker repository and report new tags
-* Include and exclude filters with regular expression for tags
-* Internal cron implementation through go routines
-* Worker pool to parallelize analyses
-* Allow overriding image os and architecture
-* [Docker](providers/docker.md), [Kubernetes](providers/kubernetes.md), [Swarm](providers/swarm.md),
-  [Nomad](providers/nomad.md), [Dockerfile](providers/dockerfile.md) and [File](providers/file.md)
-  providers available
-* Get notified through Gotify, Mail, Slack, Telegram and [more](config/index.md#reference)
-* [Healthchecks support](config/watch.md#healthchecks) to monitor Diun watcher
-* Enhanced logging
-* Official [Docker image available](install/docker.md)
+* Watch container images and report when tags or digests change
+* Track repositories with include and exclude filters for tags
+* Run checks on a schedule without needing an external cron job
+* Discover images from [Docker](providers/docker.md), [Kubernetes](providers/kubernetes.md),
+  [Swarm](providers/swarm.md), [Nomad](providers/nomad.md), [Dockerfile](providers/dockerfile.md),
+  and [File](providers/file.md) providers
+* Override target image OS and architecture when needed
+* Send notifications through Gotify, Mail, Slack, Telegram, and [more](config/index.md#reference)
+* Integrate with [Healthchecks](config/watch.md#healthchecks) to monitor the watcher itself
+* Use detailed logging to understand checks, updates, and delivery status
+* Run as a [single binary](https://github.com/crazy-max/diun/releases/latest) or with the official
+  [Docker image](install/docker.md)
 
 ## License
 

--- a/docs/install/binary.md
+++ b/docs/install/binary.md
@@ -6,25 +6,25 @@ Diun binaries are available on [releases]([[ config.repo_url ]]/releases) page.
 
 Choose the archive matching the destination platform:
 
-* [diun_[[ git.tag | trim('v') ]]_darwin_amd64.tar.gz]([[ config.repo_url ]]/releases/download/v[[ git.tag | trim('v') ]]/diun_[[ git.tag | trim('v') ]]_darwin_amd64.tar.gz)
-* [diun_[[ git.tag | trim('v') ]]_darwin_arm64.tar.gz]([[ config.repo_url ]]/releases/download/v[[ git.tag | trim('v') ]]/diun_[[ git.tag | trim('v') ]]_darwin_arm64.tar.gz)
-* [diun_[[ git.tag | trim('v') ]]_linux_386.tar.gz]([[ config.repo_url ]]/releases/download/v[[ git.tag | trim('v') ]]/diun_[[ git.tag | trim('v') ]]_linux_386.tar.gz)
-* [diun_[[ git.tag | trim('v') ]]_linux_amd64.tar.gz]([[ config.repo_url ]]/releases/download/v[[ git.tag | trim('v') ]]/diun_[[ git.tag | trim('v') ]]_linux_amd64.tar.gz)
-* [diun_[[ git.tag | trim('v') ]]_linux_arm64.tar.gz]([[ config.repo_url ]]/releases/download/v[[ git.tag | trim('v') ]]/diun_[[ git.tag | trim('v') ]]_linux_arm64.tar.gz)
-* [diun_[[ git.tag | trim('v') ]]_linux_armv5.tar.gz]([[ config.repo_url ]]/releases/download/v[[ git.tag | trim('v') ]]/diun_[[ git.tag | trim('v') ]]_linux_armv5.tar.gz)
-* [diun_[[ git.tag | trim('v') ]]_linux_armv6.tar.gz]([[ config.repo_url ]]/releases/download/v[[ git.tag | trim('v') ]]/diun_[[ git.tag | trim('v') ]]_linux_armv6.tar.gz)
-* [diun_[[ git.tag | trim('v') ]]_linux_armv7.tar.gz]([[ config.repo_url ]]/releases/download/v[[ git.tag | trim('v') ]]/diun_[[ git.tag | trim('v') ]]_linux_armv7.tar.gz)
-* [diun_[[ git.tag | trim('v') ]]_linux_ppc64le.tar.gz]([[ config.repo_url ]]/releases/download/v[[ git.tag | trim('v') ]]/diun_[[ git.tag | trim('v') ]]_linux_ppc64le.tar.gz)
-* [diun_[[ git.tag | trim('v') ]]_linux_riscv64.tar.gz]([[ config.repo_url ]]/releases/download/v[[ git.tag | trim('v') ]]/diun_[[ git.tag | trim('v') ]]_linux_riscv64.tar.gz)
-* [diun_[[ git.tag | trim('v') ]]_linux_s390x.tar.gz]([[ config.repo_url ]]/releases/download/v[[ git.tag | trim('v') ]]/diun_[[ git.tag | trim('v') ]]_linux_s390x.tar.gz)
-* [diun_[[ git.tag | trim('v') ]]_windows_386.zip]([[ config.repo_url ]]/releases/download/v[[ git.tag | trim('v') ]]/diun_[[ git.tag | trim('v') ]]_windows_386.zip)
-* [diun_[[ git.tag | trim('v') ]]_windows_amd64.zip]([[ config.repo_url ]]/releases/download/v[[ git.tag | trim('v') ]]/diun_[[ git.tag | trim('v') ]]_windows_amd64.zip)
-* [diun_[[ git.tag | trim('v') ]]_windows_arm64.zip]([[ config.repo_url ]]/releases/download/v[[ git.tag | trim('v') ]]/diun_[[ git.tag | trim('v') ]]_windows_arm64.zip)
+* [diun_[[ latest_stable_tag | trim('v') ]]_darwin_amd64.tar.gz]([[ config.repo_url ]]/releases/download/[[ latest_stable_tag ]]/diun_[[ latest_stable_tag | trim('v') ]]_darwin_amd64.tar.gz)
+* [diun_[[ latest_stable_tag | trim('v') ]]_darwin_arm64.tar.gz]([[ config.repo_url ]]/releases/download/[[ latest_stable_tag ]]/diun_[[ latest_stable_tag | trim('v') ]]_darwin_arm64.tar.gz)
+* [diun_[[ latest_stable_tag | trim('v') ]]_linux_386.tar.gz]([[ config.repo_url ]]/releases/download/[[ latest_stable_tag ]]/diun_[[ latest_stable_tag | trim('v') ]]_linux_386.tar.gz)
+* [diun_[[ latest_stable_tag | trim('v') ]]_linux_amd64.tar.gz]([[ config.repo_url ]]/releases/download/[[ latest_stable_tag ]]/diun_[[ latest_stable_tag | trim('v') ]]_linux_amd64.tar.gz)
+* [diun_[[ latest_stable_tag | trim('v') ]]_linux_arm64.tar.gz]([[ config.repo_url ]]/releases/download/[[ latest_stable_tag ]]/diun_[[ latest_stable_tag | trim('v') ]]_linux_arm64.tar.gz)
+* [diun_[[ latest_stable_tag | trim('v') ]]_linux_armv5.tar.gz]([[ config.repo_url ]]/releases/download/[[ latest_stable_tag ]]/diun_[[ latest_stable_tag | trim('v') ]]_linux_armv5.tar.gz)
+* [diun_[[ latest_stable_tag | trim('v') ]]_linux_armv6.tar.gz]([[ config.repo_url ]]/releases/download/[[ latest_stable_tag ]]/diun_[[ latest_stable_tag | trim('v') ]]_linux_armv6.tar.gz)
+* [diun_[[ latest_stable_tag | trim('v') ]]_linux_armv7.tar.gz]([[ config.repo_url ]]/releases/download/[[ latest_stable_tag ]]/diun_[[ latest_stable_tag | trim('v') ]]_linux_armv7.tar.gz)
+* [diun_[[ latest_stable_tag | trim('v') ]]_linux_ppc64le.tar.gz]([[ config.repo_url ]]/releases/download/[[ latest_stable_tag ]]/diun_[[ latest_stable_tag | trim('v') ]]_linux_ppc64le.tar.gz)
+* [diun_[[ latest_stable_tag | trim('v') ]]_linux_riscv64.tar.gz]([[ config.repo_url ]]/releases/download/[[ latest_stable_tag ]]/diun_[[ latest_stable_tag | trim('v') ]]_linux_riscv64.tar.gz)
+* [diun_[[ latest_stable_tag | trim('v') ]]_linux_s390x.tar.gz]([[ config.repo_url ]]/releases/download/[[ latest_stable_tag ]]/diun_[[ latest_stable_tag | trim('v') ]]_linux_s390x.tar.gz)
+* [diun_[[ latest_stable_tag | trim('v') ]]_windows_386.zip]([[ config.repo_url ]]/releases/download/[[ latest_stable_tag ]]/diun_[[ latest_stable_tag | trim('v') ]]_windows_386.zip)
+* [diun_[[ latest_stable_tag | trim('v') ]]_windows_amd64.zip]([[ config.repo_url ]]/releases/download/[[ latest_stable_tag ]]/diun_[[ latest_stable_tag | trim('v') ]]_windows_amd64.zip)
+* [diun_[[ latest_stable_tag | trim('v') ]]_windows_arm64.zip]([[ config.repo_url ]]/releases/download/[[ latest_stable_tag ]]/diun_[[ latest_stable_tag | trim('v') ]]_windows_arm64.zip)
 
 And extract diun:
 
 ```shell
-wget -qO- [[ config.repo_url ]]/releases/download/v[[ git.tag | trim('v') ]]/diun_[[ git.tag | trim('v') ]]_linux_amd64.tar.gz | tar -zxvf - diun
+wget -qO- [[ config.repo_url ]]/releases/download/[[ latest_stable_tag ]]/diun_[[ latest_stable_tag | trim('v') ]]_linux_amd64.tar.gz | tar -zxvf - diun
 ```
 
 After getting the binary, it can be tested with [`./diun --help`](../usage/command-line.md#global-options) command

--- a/docs/reporting-issue.md
+++ b/docs/reporting-issue.md
@@ -2,7 +2,7 @@
 
 ## Before submitting an issue
 
-First, [be a respectful](https://opensource.how/etiquette/).
+First, [be respectful](https://github.com/kossnocorp/opensource.how/blob/classic/README.md).
 
 Please do a search in [open issues]([[ config.repo_url ]]/issues?utf8=%E2%9C%93) to see if the issue or feature request has already been filed and read the [FAQ](faq.md) page first.
 

--- a/hack/docs.Dockerfile
+++ b/hack/docs.Dockerfile
@@ -1,16 +1,15 @@
 # syntax=docker/dockerfile:1
 
-ARG MKDOCS_VERSION="9.6.20"
+ARG MKDOCS_VERSION="9.7.5"
 
 FROM squidfunk/mkdocs-material:${MKDOCS_VERSION} AS base
 RUN apk add --no-cache git git-fast-import openssl gcc musl-dev \
   && pip install --no-cache-dir \
     'lunr==0.8.0' \
     'markdown-include==0.8.1' \
-    'mkdocs-awesome-pages-plugin==2.10.1' \
     'mkdocs-exclude==1.0.2' \
-    'mkdocs-git-revision-date-localized-plugin==1.3.0' \
-    'mkdocs-macros-plugin==1.4.0'
+    'mkdocs-git-revision-date-localized-plugin==1.5.1' \
+    'mkdocs-macros-plugin==1.5.0'
 
 FROM base AS generate
 RUN --mount=type=bind,target=. \

--- a/hack/mkdocs_macros.py
+++ b/hack/mkdocs_macros.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+import re
+import subprocess
+
+
+_STABLE_TAG_PATTERN = re.compile(r"^v\d+\.\d+\.\d+$")
+
+
+def _latest_stable_tag() -> str:
+    result = subprocess.run(
+        [
+            "git",
+            "tag",
+            "--merged",
+            "HEAD",
+            "--list",
+            "v[0-9]*",
+            "--sort=-version:refname",
+        ],
+        cwd=Path(__file__).resolve().parent.parent,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    for line in result.stdout.splitlines():
+        tag = line.strip()
+        if _STABLE_TAG_PATTERN.fullmatch(tag):
+            return tag
+    raise RuntimeError("no stable git tag found")
+
+
+def define_env(env) -> None:
+    env.variables["latest_stable_tag"] = _latest_stable_tag()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,12 @@ markdown_extensions:
       base_path: docs
   - meta
   - pymdownx.details
+  - pymdownx.magiclink:
+      repo_url_shorthand: true
+      repo_url_shortener: true
+      provider: github
+      user: crazy-max
+      repo: diun
   - pymdownx.emoji:
       emoji_index: !!python/name:material.extensions.emoji.twemoji
       emoji_generator: !!python/name:material.extensions.emoji.to_svg
@@ -83,6 +89,12 @@ markdown_extensions:
       permalink: true
 
 plugins:
+  - privacy:
+      assets: false
+      links: true
+      links_attr_map:
+        target: _blank
+      links_noopener: true
   - exclude:
       glob:
         - "_overrides/*"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,6 +107,7 @@ plugins:
       j2_block_end_string: '%]]'
       j2_variable_start_string: '[['
       j2_variable_end_string: ']]'
+      module_name: hack/mkdocs_macros
   - search:
       lang:
         - en


### PR DESCRIPTION
fixes #1664 

The docs build was updated to MkDocs Material 9.7.5, MkDocs now enables GitHub-style magic links and external link hardening, and the docs macros plugin now exposes the latest stable tag so binary download links point at the latest stable release instead of the current git tag.