### PR TITLE
slack: retry webhook sends after rate limits

### DIFF
--- a/internal/notif/slack/client.go
+++ b/internal/notif/slack/client.go
@@ -2,6 +2,7 @@ package slack
 
 import (
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"strconv"
 	"time"
@@ -13,6 +14,8 @@ import (
 	"github.com/nlopes/slack"
 	"github.com/pkg/errors"
 )
+
+const slackMaxRateLimitAttempts = 3
 
 // Client represents an active slack notification object
 type Client struct {
@@ -100,7 +103,7 @@ func (c *Client) Send(entry model.NotifEntry) error {
 		color = "#0054ca"
 	}
 
-	return slack.PostWebhook(webhookURL, &slack.WebhookMessage{
+	payload := &slack.WebhookMessage{
 		Attachments: []slack.Attachment{
 			{
 				Color:         color,
@@ -114,5 +117,21 @@ func (c *Client) Send(entry model.NotifEntry) error {
 				Ts:            json.Number(strconv.FormatInt(time.Now().Unix(), 10)),
 			},
 		},
-	})
+	}
+
+	for attempt := 1; attempt <= slackMaxRateLimitAttempts; attempt++ {
+		err = slack.PostWebhook(webhookURL, payload)
+		if err == nil {
+			return nil
+		}
+
+		rateLimitErr, ok := stderrors.AsType[*slack.RateLimitedError](err)
+		if !ok || attempt == slackMaxRateLimitAttempts {
+			return err
+		}
+
+		time.Sleep(rateLimitErr.RetryAfter)
+	}
+
+	return nil
 }

--- a/internal/notif/slack/client_test.go
+++ b/internal/notif/slack/client_test.go
@@ -76,6 +76,52 @@ func TestSendPostsWebhookAttachment(t *testing.T) {
 	}, attachment.Fields)
 }
 
+func TestSendRetriesAfterSlackRateLimit(t *testing.T) {
+	var requestCount int
+	var gotPayloads []map[string]interface{}
+	var gotPayloadErr error
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		var payload map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil && gotPayloadErr == nil {
+			gotPayloadErr = err
+		}
+		gotPayloads = append(gotPayloads, payload)
+
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	err := newTestClient(ts.URL).Send(testEntry(t))
+
+	require.NoError(t, err)
+	require.NoError(t, gotPayloadErr)
+	assert.Equal(t, 2, requestCount)
+	require.Len(t, gotPayloads, 2)
+	assert.Equal(t, gotPayloads[0], gotPayloads[1])
+}
+
+func TestSendStopsAfterSlackRateLimitAttempts(t *testing.T) {
+	var requestCount int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "0")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer ts.Close()
+
+	err := newTestClient(ts.URL).Send(testEntry(t))
+
+	require.ErrorContains(t, err, "slack rate limit exceeded")
+	assert.Equal(t, slackMaxRateLimitAttempts, requestCount)
+}
+
 func newTestClient(webhookURL string) *Client {
 	return &Client{
 		cfg: &model.NotifSlack{


### PR DESCRIPTION
This change makes the Slack notifier retry incoming webhook sends when Slack responds with a rate limit error that includes a retry delay.