### PR TITLE
telegram: retry sends after rate limits

### DIFF
--- a/internal/notif/telegram/client.go
+++ b/internal/notif/telegram/client.go
@@ -2,10 +2,12 @@ package telegram
 
 import (
 	"encoding/json"
+	stderrors "errors"
 	"net/http"
 	"strconv"
 	"strings"
 	"text/template"
+	"time"
 
 	"github.com/PaulSonOfLars/gotgbot/v2"
 	"github.com/crazy-max/diun/v4/internal/model"
@@ -14,6 +16,8 @@ import (
 	"github.com/crazy-max/diun/v4/internal/secret"
 	"github.com/pkg/errors"
 )
+
+const telegramMaxRateLimitAttempts = 3
 
 // Client represents an active Telegram notification object
 type Client struct {
@@ -151,11 +155,34 @@ func parseChatIDs(entries []string) ([]chatID, error) {
 }
 
 func sendTelegramMessage(bot *gotgbot.Bot, chatID int64, threadID int64, message string, disableNotification bool) error {
-	_, err := bot.SendMessage(chatID, message, &gotgbot.SendMessageOpts{
+	opts := &gotgbot.SendMessageOpts{
 		MessageThreadId:     threadID,
 		ParseMode:           gotgbot.ParseModeMarkdown,
 		LinkPreviewOptions:  &gotgbot.LinkPreviewOptions{IsDisabled: true},
 		DisableNotification: disableNotification,
-	})
-	return err
+	}
+
+	for attempt := 1; attempt <= telegramMaxRateLimitAttempts; attempt++ {
+		_, err := bot.SendMessage(chatID, message, opts)
+		if err == nil {
+			return nil
+		}
+
+		retryAfter, ok := telegramRetryAfter(err)
+		if !ok || attempt == telegramMaxRateLimitAttempts {
+			return err
+		}
+
+		time.Sleep(retryAfter)
+	}
+
+	return nil
+}
+
+func telegramRetryAfter(err error) (time.Duration, bool) {
+	telegramErr, ok := stderrors.AsType[*gotgbot.TelegramError](err)
+	if !ok || telegramErr.Code != http.StatusTooManyRequests || telegramErr.ResponseParams == nil || telegramErr.ResponseParams.RetryAfter < 0 {
+		return 0, false
+	}
+	return time.Duration(telegramErr.ResponseParams.RetryAfter) * time.Second, true
 }

--- a/internal/notif/telegram/client_test.go
+++ b/internal/notif/telegram/client_test.go
@@ -1,11 +1,115 @@
 package telegram
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/crazy-max/diun/v4/internal/model"
+	"github.com/crazy-max/diun/v4/pkg/registry"
+	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestSendRetriesAfterTelegramRateLimit(t *testing.T) {
+	var sendCount int
+	var gotEncodeErr error
+	var gotParseErr error
+	var gotTexts []string
+	var gotThreadIDs []string
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/getMe"):
+			if err := writeTelegramResponse(w, http.StatusOK, map[string]any{
+				"ok": true,
+				"result": map[string]any{
+					"id":         123,
+					"is_bot":     true,
+					"first_name": "Diun",
+				},
+			}); err != nil && gotEncodeErr == nil {
+				gotEncodeErr = err
+			}
+		case strings.HasSuffix(r.URL.Path, "/sendMessage"):
+			sendCount++
+			r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
+			if err := r.ParseMultipartForm(32 << 20); err != nil && gotParseErr == nil {
+				gotParseErr = err
+			}
+			gotTexts = append(gotTexts, r.FormValue("text"))
+			gotThreadIDs = append(gotThreadIDs, r.FormValue("message_thread_id"))
+
+			if sendCount == 1 {
+				if err := writeTelegramRateLimitResponse(w); err != nil && gotEncodeErr == nil {
+					gotEncodeErr = err
+				}
+				return
+			}
+			if err := writeTelegramResponse(w, http.StatusOK, map[string]any{
+				"ok":     true,
+				"result": map[string]any{},
+			}); err != nil && gotEncodeErr == nil {
+				gotEncodeErr = err
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	err := newTestClient(ts.URL).Send(testEntry(t))
+
+	require.NoError(t, err)
+	require.NoError(t, gotEncodeErr)
+	require.NoError(t, gotParseErr)
+	assert.Equal(t, 2, sendCount)
+	assert.Equal(t, []string{"file update", "file update"}, gotTexts)
+	assert.Equal(t, []string{"456", "456"}, gotThreadIDs)
+}
+
+func TestSendStopsAfterTelegramRateLimitAttempts(t *testing.T) {
+	var sendCount int
+	var gotEncodeErr error
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/getMe"):
+			if err := writeTelegramResponse(w, http.StatusOK, map[string]any{
+				"ok": true,
+				"result": map[string]any{
+					"id":         123,
+					"is_bot":     true,
+					"first_name": "Diun",
+				},
+			}); err != nil && gotEncodeErr == nil {
+				gotEncodeErr = err
+			}
+		case strings.HasSuffix(r.URL.Path, "/sendMessage"):
+			sendCount++
+			if err := writeTelegramRateLimitResponse(w); err != nil && gotEncodeErr == nil {
+				gotEncodeErr = err
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	err := newTestClient(ts.URL).Send(testEntry(t))
+
+	require.ErrorContains(t, err, "unable to sendMessage")
+	require.NoError(t, gotEncodeErr)
+	assert.Equal(t, telegramMaxRateLimitAttempts, sendCount)
+}
 
 func TestParseChatIDs(t *testing.T) {
 	tests := []struct {
@@ -69,4 +173,56 @@ func TestParseChatIDs(t *testing.T) {
 			require.Equal(t, tt.expected, res)
 		})
 	}
+}
+
+func newTestClient(apiURL string) *Client {
+	return &Client{
+		cfg: &model.NotifTelegram{
+			APIURL:              apiURL,
+			Token:               "123:abc",
+			ChatIDs:             []string{"123:456"},
+			TemplateBody:        "{{ .Entry.Provider }} {{ .Entry.Status }}",
+			DisableNotification: new(true),
+		},
+		meta: model.Meta{
+			Name:     "Diun",
+			Hostname: "node-1",
+		},
+	}
+}
+
+func testEntry(t *testing.T) model.NotifEntry {
+	t.Helper()
+
+	image, err := registry.ParseImage(registry.ParseImageOptions{
+		Name: "docker.io/library/alpine:latest",
+	})
+	require.NoError(t, err)
+
+	return model.NotifEntry{
+		Status:   model.ImageStatusUpdate,
+		Provider: "file",
+		Image:    image,
+		Manifest: registry.Manifest{
+			Digest:   digest.Digest("sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
+			Created:  new(time.Date(2026, 5, 24, 12, 34, 56, 0, time.UTC)),
+			Platform: "linux/amd64",
+		},
+	}
+}
+
+func writeTelegramRateLimitResponse(w http.ResponseWriter) error {
+	return writeTelegramResponse(w, http.StatusTooManyRequests, map[string]any{
+		"ok":          false,
+		"error_code":  http.StatusTooManyRequests,
+		"description": "Too Many Requests: retry later",
+		"parameters": map[string]any{
+			"retry_after": 0,
+		},
+	})
+}
+
+func writeTelegramResponse(w http.ResponseWriter, statusCode int, body map[string]any) error {
+	w.WriteHeader(statusCode)
+	return json.NewEncoder(w).Encode(body)
 }


### PR DESCRIPTION
This change makes the Telegram notifier retry `sendMessage` calls when Telegram returns a flood control response with `retry_after`.