### PR TITLE
teams: retry webhooks after rate limits

### DIFF
--- a/internal/notif/teams/client.go
+++ b/internal/notif/teams/client.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"time"
 
@@ -138,6 +139,14 @@ func (c *Client) Send(entry model.NotifEntry) error {
 		return err
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return errors.Wrap(err, "cannot read Teams error response")
+		}
+		return errors.Errorf("unexpected HTTP status %d: %s", resp.StatusCode, string(body))
+	}
 
 	return nil
 }

--- a/internal/notif/teams/client.go
+++ b/internal/notif/teams/client.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/crazy-max/diun/v4/internal/httputil"
@@ -15,6 +17,11 @@ import (
 	"github.com/crazy-max/diun/v4/internal/notif/notifier"
 	"github.com/crazy-max/diun/v4/internal/secret"
 	"github.com/pkg/errors"
+)
+
+const (
+	teamsMaxRateLimitAttempts = 3
+	teamsRateLimitMessage     = "Microsoft Teams endpoint returned HTTP error 429" // https://learn.microsoft.com/en-gb/microsoftteams/platform/webhooks-and-connectors/how-to/connectors-using?tabs=cURL%2Ctext1#rate-limiting-for-connectors
 )
 
 // Client represents an active webhook notification object
@@ -112,10 +119,6 @@ func (c *Client) Send(entry model.NotifEntry) error {
 		return err
 	}
 
-	cancelCtx, cancel := context.WithCancelCause(context.Background())
-	timeoutCtx, _ := context.WithTimeoutCause(cancelCtx, *c.cfg.Timeout, errors.WithStack(context.DeadlineExceeded)) //nolint:govet // no need to manually cancel this context as we already rely on parent
-	defer func() { cancel(errors.WithStack(context.Canceled)) }()
-
 	tlsConfig, err := httputil.LoadTLSConfig(c.cfg.TLSSkipVerify, c.cfg.TLSCACertFiles)
 	if err != nil {
 		return errors.Wrap(err, "cannot load TLS configuration for Teams notifier")
@@ -126,27 +129,74 @@ func (c *Client) Send(entry model.NotifEntry) error {
 		},
 	}
 
-	req, err := http.NewRequestWithContext(timeoutCtx, "POST", webhookURL, bytes.NewBuffer(jsonBody))
-	if err != nil {
-		return err
-	}
+	for attempt := 1; attempt <= teamsMaxRateLimitAttempts; attempt++ {
+		cancelCtx, cancel := context.WithCancelCause(context.Background())
+		timeoutCtx, _ := context.WithTimeoutCause(cancelCtx, *c.cfg.Timeout, errors.WithStack(context.DeadlineExceeded)) //nolint:govet // no need to manually cancel this context as we already rely on parent
 
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Set("User-Agent", c.meta.UserAgent)
-
-	resp, err := hc.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		body, err := io.ReadAll(resp.Body)
+		req, err := http.NewRequestWithContext(timeoutCtx, "POST", webhookURL, bytes.NewBuffer(jsonBody))
 		if err != nil {
-			return errors.Wrap(err, "cannot read Teams error response")
+			cancel(errors.WithStack(context.Canceled))
+			return err
 		}
-		return errors.Errorf("unexpected HTTP status %d: %s", resp.StatusCode, string(body))
+
+		req.Header.Add("Content-Type", "application/json")
+		req.Header.Set("User-Agent", c.meta.UserAgent)
+
+		resp, err := hc.Do(req)
+		if err != nil {
+			cancel(errors.WithStack(context.Canceled))
+			return err
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		if closeErr := resp.Body.Close(); err == nil {
+			err = closeErr
+		}
+		cancel(errors.WithStack(context.Canceled))
+		if err != nil {
+			return errors.Wrap(err, "cannot read Teams response")
+		}
+
+		if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices && !teamsRateLimited(resp, body) {
+			return nil
+		}
+
+		err = teamsResponseError(resp, body)
+		if !teamsRateLimited(resp, body) || attempt == teamsMaxRateLimitAttempts {
+			return err
+		}
+
+		time.Sleep(teamsRetryAfter(resp, attempt))
 	}
 
 	return nil
+}
+
+func teamsRateLimited(resp *http.Response, body []byte) bool {
+	return resp.StatusCode == http.StatusTooManyRequests || strings.Contains(string(body), teamsRateLimitMessage)
+}
+
+func teamsResponseError(resp *http.Response, body []byte) error {
+	if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
+		return errors.Errorf("unexpected Teams response: %s", string(body))
+	}
+	return errors.Errorf("unexpected HTTP status %d: %s", resp.StatusCode, string(body))
+}
+
+// https://learn.microsoft.com/en-us/microsoftteams/platform/bots/build-conversational-capability?tabs=dotnet%2Capp-manifest-v112-or-later%2Cdotnet2%2Cdotnet3%2Cdotnet4%2Cdotnet5%2Ccsharp2%2Cdotnet6%2Ccsharp1#status-codes-from-bot-conversational-apis
+func teamsRetryAfter(resp *http.Response, attempt int) time.Duration {
+	if value := resp.Header.Get("Retry-After"); value != "" {
+		if seconds, err := strconv.Atoi(value); err == nil && seconds >= 0 {
+			return time.Duration(seconds) * time.Second
+		}
+		if retryAt, err := http.ParseTime(value); err == nil {
+			delay := time.Until(retryAt)
+			if delay > 0 {
+				return delay
+			}
+			return 0
+		}
+	}
+
+	return time.Duration(1<<uint(attempt-1)) * time.Second
 }

--- a/internal/notif/teams/client_test.go
+++ b/internal/notif/teams/client_test.go
@@ -62,6 +62,18 @@ func TestSendPostsMessageCard(t *testing.T) {
 	}, section.Facts)
 }
 
+func TestSendReturnsTeamsErrorResponse(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("failed to deliver message"))
+	}))
+	defer ts.Close()
+
+	err := newTestClient(ts.URL).Send(testEntry(t))
+
+	require.ErrorContains(t, err, "unexpected HTTP status 500: failed to deliver message")
+}
+
 func newTestClient(webhookURL string) *Client {
 	return &Client{
 		cfg: &model.NotifTeams{

--- a/internal/notif/teams/client_test.go
+++ b/internal/notif/teams/client_test.go
@@ -74,6 +74,54 @@ func TestSendReturnsTeamsErrorResponse(t *testing.T) {
 	require.ErrorContains(t, err, "unexpected HTTP status 500: failed to deliver message")
 }
 
+func TestSendRetriesAfterTeamsRateLimit(t *testing.T) {
+	var requestCount int
+	var gotPayloads []map[string]interface{}
+	var gotPayloadErr error
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		var payload map[string]interface{}
+		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&payload); err != nil && gotPayloadErr == nil {
+			gotPayloadErr = err
+		}
+		gotPayloads = append(gotPayloads, payload)
+
+		if requestCount == 1 {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(teamsRateLimitMessage))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	err := newTestClient(ts.URL).Send(testEntry(t))
+
+	require.NoError(t, err)
+	require.NoError(t, gotPayloadErr)
+	assert.Equal(t, 2, requestCount)
+	require.Len(t, gotPayloads, 2)
+	assert.Equal(t, gotPayloads[0], gotPayloads[1])
+}
+
+func TestSendStopsAfterTeamsRateLimitAttempts(t *testing.T) {
+	var requestCount int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Retry-After", "0")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(teamsRateLimitMessage))
+	}))
+	defer ts.Close()
+
+	err := newTestClient(ts.URL).Send(testEntry(t))
+
+	require.ErrorContains(t, err, "unexpected Teams response: Microsoft Teams endpoint returned HTTP error 429")
+	assert.Equal(t, teamsMaxRateLimitAttempts, requestCount)
+}
+
 func newTestClient(webhookURL string) *Client {
 	return &Client{
 		cfg: &model.NotifTeams{


### PR DESCRIPTION
The Teams notifier now reads response bodies, returns non-success webhook responses as errors, detects the documented Teams connector rate-limit message, and retries bounded rate-limit responses with `Retry-After` when available or exponential backoff otherwise.