### PR TITLE
mail: rely on go-mail message IDs

### DIFF
--- a/internal/notif/mail/client.go
+++ b/internal/notif/mail/client.go
@@ -1,9 +1,7 @@
 package mail
 
 import (
-	"crypto/rand"
 	"crypto/tls"
-	"encoding/hex"
 	"fmt"
 	"strings"
 	"text/template"
@@ -39,31 +37,6 @@ func New(config *model.NotifMail, meta model.Meta) notifier.Notifier {
 // Name returns notifier's name
 func (c *Client) Name() string {
 	return "mail"
-}
-
-// generateMessageID creates a unique Message-ID header value according to RFC 5322.
-// Format: <timestamp.randomhex@domain>
-// The domain is taken from the LocalName config if set, otherwise falls back to Host.
-func (c *Client) generateMessageID() (string, error) {
-	// Use nanosecond timestamp for high resolution uniqueness
-	timestamp := time.Now().UnixNano()
-
-	// Generate 8 bytes of cryptographically secure random data
-	randomBytes := make([]byte, 8)
-	if _, err := rand.Read(randomBytes); err != nil {
-		return "", errors.Wrap(err, "failed to generate random bytes for Message-ID")
-	}
-	randomHex := hex.EncodeToString(randomBytes)
-
-	// Use LocalName if set, otherwise fall back to Host
-	domain := c.cfg.LocalName
-	if domain == "" {
-		domain = c.cfg.Host
-	}
-
-	// RFC 5322 format: <local-part@domain>
-	messageID := fmt.Sprintf("<%d.%s@%s>", timestamp, randomHex, domain)
-	return messageID, nil
 }
 
 // Send creates and sends an email notification with an entry
@@ -126,12 +99,6 @@ func (c *Client) Send(entry model.NotifEntry) error {
 		return errors.Wrap(err, "cannot generate plaintext email")
 	}
 
-	// Generate RFC 5322 compliant Message-ID
-	messageID, err := c.generateMessageID()
-	if err != nil {
-		return errors.Wrap(err, "cannot generate Message-ID")
-	}
-
 	mailMessage := email.NewMsg()
 	if err = mailMessage.FromFormat(c.meta.Name, c.cfg.From); err != nil {
 		return errors.Wrap(err, "cannot set mail FROM address")
@@ -140,7 +107,6 @@ func (c *Client) Send(entry model.NotifEntry) error {
 		return errors.Wrap(err, "cannot set mail TO address(es)")
 	}
 	mailMessage.Subject(string(title))
-	mailMessage.SetGenHeader(email.HeaderMessageID, messageID)
 	mailMessage.SetBodyString(email.TypeTextPlain, textpart)
 	mailMessage.AddAlternativeString(email.TypeTextHTML, htmlpart)
 

--- a/internal/notif/mail/client_test.go
+++ b/internal/notif/mail/client_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net"
 	"net/textproto"
-	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -15,122 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 	email "github.com/wneessen/go-mail"
 )
-
-func TestGenerateMessageID(t *testing.T) {
-	// RFC 5322 Message-ID format: <local-part@domain>
-	// local-part should contain: timestamp.randomhex
-	messageIDRegex := regexp.MustCompile(`^<\d+\.[0-9a-f]+@.+>$`)
-
-	tests := []struct {
-		name       string
-		cfg        *model.NotifMail
-		wantDomain string
-	}{
-		{
-			name: "with LocalName",
-			cfg: &model.NotifMail{
-				Host:      "smtp.example.com",
-				LocalName: "mail.mydomain.com",
-			},
-			wantDomain: "mail.mydomain.com",
-		},
-		{
-			name: "fallback to Host",
-			cfg: &model.NotifMail{
-				Host:      "smtp.example.com",
-				LocalName: "",
-			},
-			wantDomain: "smtp.example.com",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			client := &Client{
-				cfg: tt.cfg,
-			}
-
-			messageID, err := client.generateMessageID()
-			require.NoError(t, err, "generateMessageID should not return an error")
-			assert.NotEmpty(t, messageID, "Message-ID should not be empty")
-
-			// Verify RFC 5322 format
-			assert.True(t, messageIDRegex.MatchString(messageID),
-				"Message-ID should match RFC 5322 format: %s", messageID)
-
-			// Verify it contains the expected domain
-			assert.Contains(t, messageID, tt.wantDomain,
-				"Message-ID should contain domain %s: %s", tt.wantDomain, messageID)
-
-			// Verify structure: <timestamp.randomhex@domain>
-			assert.True(t, strings.HasPrefix(messageID, "<"), "Message-ID should start with <")
-			assert.True(t, strings.HasSuffix(messageID, ">"), "Message-ID should end with >")
-			assert.Contains(t, messageID, "@", "Message-ID should contain @")
-			assert.Contains(t, messageID, ".", "Message-ID should contain . separator")
-		})
-	}
-}
-
-func TestGenerateMessageID_Uniqueness(t *testing.T) {
-	client := &Client{
-		cfg: &model.NotifMail{
-			Host:      "smtp.example.com",
-			LocalName: "mail.example.com",
-		},
-	}
-
-	// Generate multiple Message-IDs and verify they are unique
-	messageIDs := make(map[string]bool)
-	iterations := 1000
-
-	for i := 0; i < iterations; i++ {
-		messageID, err := client.generateMessageID()
-		require.NoError(t, err)
-		assert.False(t, messageIDs[messageID], "Message-ID should be unique: %s", messageID)
-		messageIDs[messageID] = true
-	}
-
-	assert.Len(t, messageIDs, iterations, "All generated Message-IDs should be unique")
-}
-
-func TestGenerateMessageID_Format(t *testing.T) {
-	client := &Client{
-		cfg: &model.NotifMail{
-			Host:      "smtp.example.com",
-			LocalName: "mail.example.com",
-		},
-	}
-
-	messageID, err := client.generateMessageID()
-	require.NoError(t, err)
-
-	// Remove angle brackets
-	messageID = strings.TrimPrefix(messageID, "<")
-	messageID = strings.TrimSuffix(messageID, ">")
-
-	// Split by @
-	parts := strings.Split(messageID, "@")
-	require.Len(t, parts, 2, "Message-ID should have exactly one @ symbol")
-
-	localPart := parts[0]
-	domain := parts[1]
-
-	// Verify local part contains timestamp.randomhex
-	localParts := strings.Split(localPart, ".")
-	require.Len(t, localParts, 2, "Local part should be timestamp.randomhex")
-
-	// Verify timestamp is numeric
-	timestamp := localParts[0]
-	assert.Regexp(t, `^\d+$`, timestamp, "Timestamp should be numeric")
-
-	// Verify random part is hex (16 characters for 8 bytes)
-	randomHex := localParts[1]
-	assert.Len(t, randomHex, 16, "Random hex should be 16 characters (8 bytes)")
-	assert.Regexp(t, `^[0-9a-f]+$`, randomHex, "Random part should be hex")
-
-	// Verify domain
-	assert.Equal(t, "mail.example.com", domain, "Domain should match LocalName")
-}
 
 func TestSendSMTPRegression(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
This change removes Diun's custom Message-ID generation for mail notifications and relies on go-mail to add its default Message-ID header when sending messages.