### PR TITLE
mail: use default HELO when localName is unset

### DIFF
--- a/docs/notif/mail.md
+++ b/docs/notif/mail.md
@@ -27,7 +27,7 @@ Notifications can be sent through SMTP.
 | `port`[^1]           | `25`                                | SMTP server port                                                                                                                   |
 | `ssl`                | `false`                             | SSL defines whether an SSL connection is used. Should be false in most cases since the auth mechanism should use STARTTLS          |
 | `insecureSkipVerify` | `false`                             | Controls whether a client verifies the server's certificate chain and hostname                                                     |
-| `localName`          | `localhost`                         | Hostname sent to the SMTP server with the HELO command                                                                             |
+| `localName`          |                                     | Hostname sent to the SMTP server with the HELO command. If unset, uses the OS hostname                                             |
 | `username`           |                                     | SMTP username                                                                                                                      |
 | `usernameFile`       |                                     | Use content of [secret file](../faq.md#secrets-loaded-from-files-and-trailing-newlines) as SMTP username if `username` not defined |
 | `password`           |                                     | SMTP password                                                                                                                      |

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -116,7 +116,6 @@ func TestLoadFile(t *testing.T) {
 						Port:               25,
 						SSL:                new(false),
 						InsecureSkipVerify: new(false),
-						LocalName:          "localhost",
 						From:               "diun@example.com",
 						To: []string{
 							"webmaster@example.com",

--- a/internal/model/notif_mail.go
+++ b/internal/model/notif_mail.go
@@ -41,7 +41,6 @@ func (s *NotifMail) SetDefaults() {
 	s.Port = 25
 	s.SSL = new(false)
 	s.InsecureSkipVerify = new(false)
-	s.LocalName = "localhost"
 	s.TemplateTitle = NotifDefaultTemplateTitle
 	s.TemplateBody = NotifMailDefaultTemplateBody
 }

--- a/internal/notif/mail/client.go
+++ b/internal/notif/mail/client.go
@@ -131,14 +131,12 @@ func (c *Client) Send(entry model.NotifEntry) error {
 }
 
 func (c *Client) mailClient(username, password string) (*email.Client, error) {
-	localName := c.cfg.LocalName
-	if localName == "" {
-		localName = "localhost"
-	}
 	opts := []email.Option{
 		email.WithPort(c.cfg.Port),
 		email.WithTLSPolicy(email.TLSOpportunistic),
-		email.WithHELO(localName),
+	}
+	if c.cfg.LocalName != "" {
+		opts = append(opts, email.WithHELO(c.cfg.LocalName))
 	}
 	if *c.cfg.SSL {
 		opts = append(opts, email.WithSSL())

--- a/internal/notif/mail/client_test.go
+++ b/internal/notif/mail/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net"
 	"net/textproto"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -16,6 +17,9 @@ import (
 )
 
 func TestSendSMTPRegression(t *testing.T) {
+	hostname, err := os.Hostname()
+	require.NoError(t, err)
+
 	tests := []struct {
 		name          string
 		localName     string
@@ -28,10 +32,10 @@ func TestSendSMTPRegression(t *testing.T) {
 			wantHelo:  "mail.example.com",
 		},
 		{
-			name:          "empty localName falls back to localhost without forcing auth",
+			name:          "empty localName uses go-mail default without forcing auth",
 			localName:     "",
 			advertiseAuth: true,
-			wantHelo:      "localhost",
+			wantHelo:      hostname,
 		},
 	}
 


### PR DESCRIPTION
This change makes `localName` opt in for mail notifications, so Diun only overrides the SMTP HELO value when users configure it explicitly.