### PR TITLE
add string helpers to notification templates

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -83,6 +83,26 @@ Templating is supported with the following fields:
 | `.Entry.Manifest.Platform`      | Platform that the image is runs on. e.g. `linux/amd64`                                |
 | `.Entry.Metadata`               | Key-value pair of image metadata specific to each provider                            |
 
+The following helper functions are also available in notification templates.
+Helpers that operate on a string take the target string as their last argument,
+so they can be used directly or in a pipeline.
+
+| Function          | Description                             | Example                                                      |
+|-------------------|-----------------------------------------|--------------------------------------------------------------|
+| `lower`           | Converts a string to lower case         | `{{ lower .Entry.Image.Tag }}`                               |
+| `upper`           | Converts a string to upper case         | `{{ upper .Entry.Image.Tag }}`                               |
+| `replace`         | Replaces all occurrences of a substring | `{{ replace "/" "-" .Entry.Image.Path }}`                    |
+| `trim`            | Removes leading and trailing whitespace | `{{ trim .Entry.Metadata.foo }}`                             |
+| `trimPrefix`      | Removes a prefix if present             | `{{ trimPrefix "v" .Entry.Image.Tag }}`                      |
+| `trimSuffix`      | Removes a suffix if present             | `{{ trimSuffix "-alpine" .Entry.Image.Tag }}`                |
+| `regexReplaceAll` | Replaces all regular expression matches | `{{ regexReplaceAll "[^a-zA-Z0-9]+" "-" .Entry.Image.Tag }}` |
+
+For example, this normalizes an image path with a pipeline:
+
+```gotemplate
+{{ .Entry.Image.Path | replace "/" "-" | lower }}
+```
+
 ## Authentication against the registry
 
 You can authenticate against the registry through the [`regopts` settings](config/regopts.md) or you can mount

--- a/internal/msg/client.go
+++ b/internal/msg/client.go
@@ -56,7 +56,7 @@ func (c *Client) RenderMarkdown() (title []byte, body []byte, _ error) {
 // RenderTemplate renders a notification template with the entry context.
 func (c *Client) RenderTemplate(name, text string) ([]byte, error) {
 	var buf bytes.Buffer
-	tpl, err := template.New(name).Funcs(c.opts.TemplateFuncs).Parse(strings.TrimSuffix(strings.TrimSpace(text), "\n"))
+	tpl, err := template.New(name).Funcs(templateFuncs(c.opts.TemplateFuncs)).Parse(strings.TrimSuffix(strings.TrimSpace(text), "\n"))
 	if err != nil {
 		return nil, errors.Wrapf(err, "cannot parse %s template", name)
 	}

--- a/internal/msg/client_test.go
+++ b/internal/msg/client_test.go
@@ -30,6 +30,35 @@ func TestRenderMarkdown(t *testing.T) {
 	assert.Equal(t, "node-1 saw docker.io/crazymax/diun:1.2.3 from file", string(body))
 }
 
+func TestRenderMarkdownUsesDefaultTemplateFuncs(t *testing.T) {
+	client := newTestClient(t, Options{
+		TemplateTitle: `{{ replace "." "-" .Entry.Image.Tag }}`,
+		TemplateBody:  `{{ trim "  Padded Value  " }} {{ trimPrefix "v" "v1.2.3" }} {{ trimSuffix "-alpine" "1.2.3-alpine" }} {{ regexReplaceAll "[^0-9]+" "-" .Entry.Image.Tag }} {{ lower "DIUN" }} {{ upper "diun" }}`,
+	})
+
+	title, body, err := client.RenderMarkdown()
+	require.NoError(t, err)
+
+	assert.Equal(t, "1-2-3", string(title))
+	assert.Equal(t, "Padded Value 1.2.3 1.2.3 1-2-3 diun DIUN", string(body))
+}
+
+func TestRenderMarkdownAllowsTemplateFuncOverrides(t *testing.T) {
+	client := newTestClient(t, Options{
+		TemplateTitle: `{{ upper .Entry.Image.Tag }} {{ lower "DIUN" }}`,
+		TemplateFuncs: template.FuncMap{
+			"upper": func(string) string {
+				return "custom"
+			},
+		},
+	})
+
+	title, _, err := client.RenderMarkdown()
+	require.NoError(t, err)
+
+	assert.Equal(t, "custom diun", string(title))
+}
+
 func TestRenderMarkdownReturnsTemplateErrors(t *testing.T) {
 	client := newTestClient(t, Options{
 		TemplateTitle: "{{ unknown .Entry.Image }}",
@@ -39,6 +68,18 @@ func TestRenderMarkdownReturnsTemplateErrors(t *testing.T) {
 	_, _, err := client.RenderMarkdown()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot parse title template")
+}
+
+func TestRenderMarkdownReturnsTemplateFuncErrors(t *testing.T) {
+	client := newTestClient(t, Options{
+		TemplateTitle: `{{ regexReplaceAll "[" "-" .Entry.Image.Tag }}`,
+		TemplateBody:  "body",
+	})
+
+	_, _, err := client.RenderMarkdown()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot render notif title")
+	assert.Contains(t, err.Error(), "error calling regexReplaceAll")
 }
 
 func TestRenderHTMLPreservesLeadingPAndSanitizesBody(t *testing.T) {

--- a/internal/msg/template.go
+++ b/internal/msg/template.go
@@ -1,0 +1,35 @@
+package msg
+
+import (
+	"regexp"
+	"strings"
+	"text/template"
+)
+
+func templateFuncs(overrides template.FuncMap) template.FuncMap {
+	funcs := template.FuncMap{
+		"lower": strings.ToLower,
+		"regexReplaceAll": func(pattern, repl, s string) (string, error) {
+			re, err := regexp.Compile(pattern)
+			if err != nil {
+				return "", err
+			}
+			return re.ReplaceAllString(s, repl), nil
+		},
+		"replace": func(old, new, s string) string {
+			return strings.ReplaceAll(s, old, new)
+		},
+		"trim": strings.TrimSpace,
+		"trimPrefix": func(prefix, s string) string {
+			return strings.TrimPrefix(s, prefix)
+		},
+		"trimSuffix": func(suffix, s string) string {
+			return strings.TrimSuffix(s, suffix)
+		},
+		"upper": strings.ToUpper,
+	}
+	for name, fn := range overrides {
+		funcs[name] = fn
+	}
+	return funcs
+}


### PR DESCRIPTION
fixes #1589

This adds a small stdlib-backed set of string helper functions to notification templates so users can normalize image names, tags, metadata, and other template values without pulling in Sprig.

Notification template rendering now registers helpers for `lower`, `upper`, `replace`, `trim`, `trimPrefix`, `trimSuffix`, and `regexReplaceAll`, while still allowing notifier-specific functions such as `escapeMarkdown` to extend or override the default function map.