### PR TITLE
skip generated artifact tags during registry checks

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -53,6 +53,8 @@ jobs:
             loglevel: debug
           - folder: file1
             loglevel: debug
+          - folder: file-artifact
+            loglevel: debug
     steps:
       -
         name: Checkout

--- a/internal/app/job.go
+++ b/internal/app/job.go
@@ -135,12 +135,13 @@ func (di *Diun) createJob(job model.Job) {
 		return
 	}
 
-	log.Debug().Str("image", job.RegImage.String()).Msgf("%d tag(s) found in repository. %d will be analyzed (%d max, %d not included, %d excluded).",
+	log.Debug().Str("image", job.RegImage.String()).Msgf("%d tag(s) found in repository. %d will be analyzed (%d max, %d not included, %d excluded, %d artifact tags).",
 		tags.Total,
 		len(tags.List),
 		job.Image.MaxTags,
 		tags.NotIncluded,
 		tags.Excluded,
+		tags.Artifacts,
 	)
 
 	for _, tag := range tags.List {

--- a/pkg/registry/tags.go
+++ b/pkg/registry/tags.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 	"unicode"
@@ -12,11 +13,14 @@ import (
 	"golang.org/x/mod/semver"
 )
 
+var generatedArtifactTagRe = regexp.MustCompile(`^sha256-[a-f0-9]{64}(?:\.(?:att|sbom|sig))?$`)
+
 // Tags holds information about image tags.
 type Tags struct {
 	List        []string
 	NotIncluded int
 	Excluded    int
+	Artifacts   int
 	Total       int
 }
 
@@ -55,7 +59,10 @@ func (c *Client) Tags(opts TagsOptions) (*Tags, error) {
 
 	// Filter
 	for _, tag := range tags {
-		if !matcher.IsIncluded(tag, opts.Include) {
+		if generatedArtifactTagRe.MatchString(tag) {
+			res.Artifacts++
+			continue
+		} else if !matcher.IsIncluded(tag, opts.Include) {
 			res.NotIncluded++
 			continue
 		} else if matcher.IsExcluded(tag, opts.Exclude) {

--- a/pkg/registry/tags_test.go
+++ b/pkg/registry/tags_test.go
@@ -58,6 +58,35 @@ func TestTagsWithDigest(t *testing.T) {
 	}, tags)
 }
 
+func TestTagsSkipsGeneratedArtifactTags(t *testing.T) {
+	registry := newTestRegistry(t, "acme/diun")
+	registry.addTagsPage("", []string{
+		"1.0.0",
+		"sha256-64677ff7a877079df86d4a12e80e67a9548ea0facb2acb8c6719e79088e64526",
+		"sha256-64677ff7a877079df86d4a12e80e67a9548ea0facb2acb8c6719e79088e64526.att",
+		"sha256-64677ff7a877079df86d4a12e80e67a9548ea0facb2acb8c6719e79088e64526.sbom",
+		"sha256-64677ff7a877079df86d4a12e80e67a9548ea0facb2acb8c6719e79088e64526.sig",
+		"sha256-not-a-digest",
+	}, "")
+
+	image, err := ParseImage(ParseImageOptions{
+		Name: registry.imageName("1.0.0"),
+	})
+	require.NoError(t, err)
+
+	client := newTestRegistryClient(t, Options{})
+	tags, err := client.Tags(TagsOptions{
+		Image: image,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, &Tags{
+		List:      []string{"1.0.0", "sha256-not-a-digest"},
+		Artifacts: 4,
+		Total:     6,
+	}, tags)
+}
+
 func TestTagsSort(t *testing.T) {
 	testCases := []struct {
 		name     string

--- a/test/file-artifact/diun.yml
+++ b/test/file-artifact/diun.yml
@@ -1,0 +1,7 @@
+watch:
+  workers: 20
+  schedule: "0 */6 * * *"
+
+providers:
+  file:
+    filename: /mount/config.yml

--- a/test/file-artifact/mount/config.yml
+++ b/test/file-artifact/mount/config.yml
@@ -1,0 +1,5 @@
+- name: ghcr.io/crazy-max/7zip:edge
+  watch_repo: true
+  include_tags:
+    - ^17
+    - ^sha256-c77e456


### PR DESCRIPTION
This change prevents Diun from scheduling registry manifest checks for generated OCI artifact tags that are commonly created by cosign and exposed by registries such as GHCR

Diun now filters repository tags that match generated digest-style artifact tags before they are added to the watch list. The filter covers tags such as `sha256-<64 lowercase hex>`, `sha256-<64 lowercase hex>.sig`, `sha256-<64 lowercase hex>.att`, and `sha256-<64 lowercase hex>.sbom`. The repository scan debug log now reports how many artifact tags were filtered.

The was observed with this log line:

```
diun  | Thu, 28 May 2026 21:12:28 CEST WRN github.com/crazy-max/diun/v4/internal/app/job.go:200 > Cannot get remote manifest error="cannot inspect: unsupported image-specific operation on artifact with type \"application/vnd.dev.sigstore.bundle.v0.3+json\"" image=ghcr.io/crazy-max/7zip:sha256-c77e456c40e42f2a8dc12df77787b4beee7412debc87d18acc332dac1b1e80ce provider=file
```

This happens because `watch_repo` receives all tag names from the registry, including generated sigstore artifact tags, and Diun previously treated every returned tag as a container image tag. A manifest `HEAD` request is not enough to identify this case because the artifact type is stored inside the manifest body, so filtering the well-known generated tag shape before manifest analysis avoids unnecessary manifest requests and avoids spending pull-rate quota on tags that are not image releases.