### PR TITLE
skip non-image artifacts during registry checks

### DIFF
--- a/internal/app/job.go
+++ b/internal/app/job.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	stderrors "errors"
 	"fmt"
 	"regexp"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/crazy-max/diun/v4/internal/secret"
 	"github.com/crazy-max/diun/v4/pkg/registry"
 	"github.com/rs/zerolog/log"
+	podmanmanifest "go.podman.io/image/v5/manifest"
 	"go.podman.io/image/v5/pkg/docker/config"
 	"go.podman.io/image/v5/types"
 )
@@ -198,6 +200,11 @@ func (di *Diun) runJob(job model.Job) (entry model.NotifEntry) {
 	var updated bool
 	entry.Manifest, updated, err = job.Registry.Manifest(job.RegImage, dbManifest)
 	if err != nil {
+		if _, ok := stderrors.AsType[podmanmanifest.NonImageArtifactError](err); ok {
+			entry.Status = model.ImageStatusSkip
+			sublog.Debug().Err(err).Msg("Skipping non-image artifact")
+			return
+		}
 		sublog.Warn().Err(err).Msg("Cannot get remote manifest")
 		return
 	}

--- a/pkg/registry/manifest_test.go
+++ b/pkg/registry/manifest_test.go
@@ -1,7 +1,9 @@
 package registry
 
 import (
+	stderrors "errors"
 	"net/http"
+	"strconv"
 	"testing"
 
 	digest "github.com/opencontainers/go-digest"
@@ -184,6 +186,27 @@ func TestManifestVariant(t *testing.T) {
 	assert.Equal(t, registry.host()+"/acme/diun", manifest.Name)
 	assert.Equal(t, "multi", manifest.Tag)
 	assert.Equal(t, "linux/arm/v7", manifest.Platform)
+}
+
+func TestManifestNonImageArtifact(t *testing.T) {
+	const sigstoreBundleType = "application/vnd.dev.sigstore.bundle.v0.3+json"
+
+	registry := newTestRegistry(t, "acme/diun")
+	artifact := newTestOCIArtifactManifest(t, sigstoreBundleType)
+	registry.addManifest("sha256-64677ff7a877079df86d4a12e80e67a9548ea0facb2acb8c6719e79088e64526", artifact)
+
+	image, err := ParseImage(ParseImageOptions{
+		Name: registry.imageName("sha256-64677ff7a877079df86d4a12e80e67a9548ea0facb2acb8c6719e79088e64526"),
+	})
+	require.NoError(t, err)
+
+	client := newTestRegistryClient(t, Options{CompareDigest: true})
+	_, _, err = client.Manifest(image, Manifest{})
+	require.Error(t, err)
+
+	_, ok := stderrors.AsType[podmanmanifest.NonImageArtifactError](err)
+	assert.True(t, ok)
+	assert.Contains(t, err.Error(), "unsupported image-specific operation on artifact with type "+strconv.Quote(sigstoreBundleType))
 }
 
 func TestManifestTaggedDigestUnknownTag(t *testing.T) {

--- a/pkg/registry/testutil_test.go
+++ b/pkg/registry/testutil_test.go
@@ -292,6 +292,44 @@ func newTestManifestList(t *testing.T, instances ...testManifestListInstance) te
 	}
 }
 
+func newTestOCIArtifactManifest(t *testing.T, artifactType string) testRegistryBlob {
+	t.Helper()
+
+	emptyConfig := []byte("{}")
+	artifactLayer := []byte(`{"mediaType":"` + artifactType + `"}`)
+
+	body, err := json.Marshal(struct {
+		SchemaVersion int                      `json:"schemaVersion"`
+		MediaType     string                   `json:"mediaType"`
+		ArtifactType  string                   `json:"artifactType"`
+		Config        testRegistryDescriptor   `json:"config"`
+		Layers        []testRegistryDescriptor `json:"layers"`
+	}{
+		SchemaVersion: 2,
+		MediaType:     imgspecv1.MediaTypeImageManifest,
+		ArtifactType:  artifactType,
+		Config: testRegistryDescriptor{
+			MediaType: imgspecv1.MediaTypeEmptyJSON,
+			Size:      int64(len(emptyConfig)),
+			Digest:    digest.FromBytes(emptyConfig),
+		},
+		Layers: []testRegistryDescriptor{
+			{
+				MediaType: artifactType,
+				Size:      int64(len(artifactLayer)),
+				Digest:    digest.FromBytes(artifactLayer),
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	return testRegistryBlob{
+		mediaType: imgspecv1.MediaTypeImageManifest,
+		body:      body,
+		digest:    digest.FromBytes(body),
+	}
+}
+
 type testManifestListInstance struct {
 	manifest testRegistryBlob
 	platform imgspecv1.Platform


### PR DESCRIPTION
This change makes Diun skip OCI artifacts that containers/image reports through `manifest.NonImageArtifactError` instead of logging them as remote manifest failures.

When registry manifest inspection returns `manifest.NonImageArtifactError`, Diun now marks the entry as skipped and logs it at debug level. The change also adds a regression test for a sigstore bundle artifact with type `application/vnd.dev.sigstore.bundle.v0.3+json`, which matches the failure seen with `ghcr.io/crazy-max/7zip:sha256-64677ff7a877079df86d4a12e80e67a9548ea0facb2acb8c6719e79088e64526`.

GHCR can expose cosign-created artifact references through repository tags, and Diun can then try to inspect a sigstore bundle as if it were an image. In that case containers/image returns an error like `cannot inspect: unsupported image-specific operation on artifact with type "application/vnd.dev.sigstore.bundle.v0.3+json"`, which is expected for a non-image artifact and should not be treated as a registry failure. This is complementary to https://github.com/crazy-max/diun/pull/1745, because that PR handles filtering generated artifact tags earlier, while this PR handles the remaining cases where a non-image artifact still reaches manifest inspection.