### PR TITLE
Add proxy support for HTTP notifiers

### DIFF
--- a/docs/notif/apprise.md
+++ b/docs/notif/apprise.md
@@ -26,6 +26,7 @@ Notifications can be sent using an apprise api instance.
 | `tags`           |                                     | List of Tags in your config file you want to notify                                                                                 |
 | `urls`[^2]       |                                     | List of [URLs](https://github.com/caronc/apprise/wiki/URLBasics) to notify                                                          |
 | `timeout`        | `10s`                               | Timeout specifies a time limit for the request to be made                                                                           |
+| `proxy`          |                                     | HTTP proxy URL to use for requests                                                                                                  |
 | `tlsSkipVerify`  | `false`                             | Skip TLS certificate verification                                                                                                   |
 | `tlsCaCertFiles` |                                     | List of paths to custom CA certificate files to use for TLS verification                                                            |
 | `templateTitle`  | See [below](#default-templatetitle) | [Notification template](../faq.md#notification-template) for message title                                                          |
@@ -37,6 +38,7 @@ Notifications can be sent using an apprise api instance.
     * `DIUN_NOTIF_APPRISE_TAGS`
     * `DIUN_NOTIF_APPRISE_URLS`
     * `DIUN_NOTIF_APPRISE_TIMEOUT`
+    * `DIUN_NOTIF_APPRISE_PROXY`
     * `DIUN_NOTIF_APPRISE_TLSSKIPVERIFY`
     * `DIUN_NOTIF_APPRISE_TLSCACERTFILES`
     * `DIUN_NOTIF_APPRISE_TEMPLATETITLE`

--- a/docs/notif/discord.md
+++ b/docs/notif/discord.md
@@ -30,6 +30,7 @@ Allow sending notifications to your Discord channel.
 | `renderEmbeds`     | `true`                             | Render [message embeds](https://discordjs.guide/legacy/popular-topics/embeds)                                                         |
 | `renderFields`     | `true`                             | Render [field objects](https://discordjs.guide/legacy/popular-topics/embeds) in message embeds                                        |
 | `timeout`          | `10s`                              | Timeout specifies a time limit for the request to be made                                                                             |
+| `proxy`            |                                    | HTTP proxy URL to use for requests                                                                                                    |
 | `templateBody`[^1] | See [below](#default-templatebody) | [Notification template](../faq.md#notification-template) for message body                                                             |
 
 !!! abstract "Environment variables"
@@ -39,6 +40,7 @@ Allow sending notifications to your Discord channel.
     * `DIUN_NOTIF_DISCORD_RENDEREMBEDS`
     * `DIUN_NOTIF_DISCORD_RENDERFIELDS`
     * `DIUN_NOTIF_DISCORD_TIMEOUT`
+    * `DIUN_NOTIF_DISCORD_PROXY`
     * `DIUN_NOTIF_DISCORD_TEMPLATEBODY`
 
 ### Default `templateBody`

--- a/docs/notif/elasticsearch.md
+++ b/docs/notif/elasticsearch.md
@@ -26,6 +26,7 @@ Send notifications to your Elasticsearch cluster as structured documents.
 | `client`[^1]     | `diun`                  | Client name to identify the source of notifications                                                                              |
 | `index`[^1]      | `diun-notifications`    | Elasticsearch index name where notifications will be stored                                                                      |
 | `timeout`        | `10s`                   | Timeout specifies a time limit for the request to be made                                                                        |
+| `proxy`          |                         | HTTP proxy URL to use for requests                                                                                               |
 | `tlsSkipVerify`  | `false`                 | Skip TLS certificate verification                                                                                                |
 | `tlsCaCertFiles` |                         | List of paths to custom CA certificate files to use for TLS verification                                                         |
 
@@ -38,6 +39,7 @@ Send notifications to your Elasticsearch cluster as structured documents.
     * `DIUN_NOTIF_ELASTICSEARCH_CLIENT`
     * `DIUN_NOTIF_ELASTICSEARCH_INDEX`
     * `DIUN_NOTIF_ELASTICSEARCH_TIMEOUT`
+    * `DIUN_NOTIF_ELASTICSEARCH_PROXY`
     * `DIUN_NOTIF_ELASTICSEARCH_TLSSKIPVERIFY`
     * `DIUN_NOTIF_ELASTICSEARCH_TLSCACERTFILES`
 

--- a/docs/notif/gotify.md
+++ b/docs/notif/gotify.md
@@ -24,6 +24,7 @@ Notifications can be sent using a [Gotify](https://gotify.net/) instance.
 | `tokenFile`         |                                     | Use content of [secret file](../faq.md#secrets-loaded-from-files-and-trailing-newlines) as application token if `token` not defined |
 | `priority`          | `1`                                 | The priority of the message                                                                                                         |
 | `timeout`           | `10s`                               | Timeout specifies a time limit for the request to be made                                                                           |
+| `proxy`             |                                     | HTTP proxy URL to use for requests                                                                                                  |
 | `tlsSkipVerify`     | `false`                             | Skip TLS certificate verification                                                                                                   |
 | `tlsCaCertFiles`    |                                     | List of paths to custom CA certificate files to use for TLS verification                                                            |
 | `templateTitle`[^1] | See [below](#default-templatetitle) | [Notification template](../faq.md#notification-template) for message title                                                          |
@@ -35,6 +36,7 @@ Notifications can be sent using a [Gotify](https://gotify.net/) instance.
     * `DIUN_NOTIF_GOTIFY_TOKENFILE`
     * `DIUN_NOTIF_GOTIFY_PRIORITY`
     * `DIUN_NOTIF_GOTIFY_TIMEOUT`
+    * `DIUN_NOTIF_GOTIFY_PROXY`
     * `DIUN_NOTIF_GOTIFY_TLSSKIPVERIFY`
     * `DIUN_NOTIF_GOTIFY_TLSCACERTFILES`
     * `DIUN_NOTIF_GOTIFY_TEMPLATETITLE`

--- a/docs/notif/ntfy.md
+++ b/docs/notif/ntfy.md
@@ -32,6 +32,7 @@ Notifications can be sent using a [ntfy](https://ntfy.sh/) instance.
 | `icon`              | Diun logo                           | URL to use as notification icon                                                                                               |
 | `click`             |                                     | [URL to open](https://docs.ntfy.sh/publish/#click-action) when the notification is clicked. Supports notification templates   |
 | `timeout`           | `10s`                               | Timeout specifies a time limit for the request to be made                                                                     |
+| `proxy`             |                                     | HTTP proxy URL to use for requests                                                                                            |
 | `tlsSkipVerify`     | `false`                             | Skip TLS certificate verification                                                                                             |
 | `tlsCaCertFiles`    |                                     | List of paths to custom CA certificate files to use for TLS verification                                                      |
 | `templateTitle`[^1] | See [below](#default-templatetitle) | [Notification template](../faq.md#notification-template) for message title                                                    |
@@ -47,6 +48,7 @@ Notifications can be sent using a [ntfy](https://ntfy.sh/) instance.
     * `DIUN_NOTIF_NTFY_ICON`
     * `DIUN_NOTIF_NTFY_CLICK`
     * `DIUN_NOTIF_NTFY_TIMEOUT`
+    * `DIUN_NOTIF_NTFY_PROXY`
     * `DIUN_NOTIF_NTFY_TLSSKIPVERIFY`
     * `DIUN_NOTIF_NTFY_TLSCACERTFILES`
     * `DIUN_NOTIF_NTFY_TEMPLATETITLE`

--- a/docs/notif/pushover.md
+++ b/docs/notif/pushover.md
@@ -27,6 +27,7 @@ You can send notifications using [Pushover](https://pushover.net/).
 | `priority`          |                                     | Priority of the notification                                                                                                                     |
 | `sound`             |                                     | Notification sound to be used                                                                                                                    |
 | `timeout`           | `10s`                               | Timeout specifies a time limit for the request to be made                                                                                        |
+| `proxy`             |                                     | HTTP proxy URL to use for requests                                                                                                               |
 | `templateTitle`[^1] | See [below](#default-templatetitle) | [Notification template](../faq.md#notification-template) for message title                                                                       |
 | `templateBody`[^1]  | See [below](#default-templatebody)  | [Notification template](../faq.md#notification-template) for message body                                                                        |
 
@@ -38,6 +39,7 @@ You can send notifications using [Pushover](https://pushover.net/).
     * `DIUN_NOTIF_PUSHOVER_PRIORITY`
     * `DIUN_NOTIF_PUSHOVER_SOUND`
     * `DIUN_NOTIF_PUSHOVER_TIMEOUT`
+    * `DIUN_NOTIF_PUSHOVER_PROXY`
     * `DIUN_NOTIF_PUSHOVER_TEMPLATETITLE`
     * `DIUN_NOTIF_PUSHOVER_TEMPLATEBODY`
 

--- a/docs/notif/rocketchat.md
+++ b/docs/notif/rocketchat.md
@@ -28,6 +28,7 @@ Allow sending notifications to your Rocket.Chat channel.
 | `tokenFile`         |                                     | Use content of [secret file](../faq.md#secrets-loaded-from-files-and-trailing-newlines) as authentication token if `token` not defined |
 | `renderAttachment`  | `true`                              | Render [attachment object](https://docs.rocket.chat/guides/user-guides/messaging#send-attachments)                                     |
 | `timeout`           | `10s`                               | Timeout specifies a time limit for the request to be made                                                                              |
+| `proxy`             |                                     | HTTP proxy URL to use for requests                                                                                                     |
 | `tlsSkipVerify`     | `false`                             | Skip TLS certificate verification                                                                                                      |
 | `tlsCaCertFiles`    |                                     | List of paths to custom CA certificate files to use for TLS verification                                                               |
 | `templateTitle`[^1] | See [below](#default-templatetitle) | [Notification template](../faq.md#notification-template) for message title                                                             |
@@ -46,6 +47,7 @@ Allow sending notifications to your Rocket.Chat channel.
     * `DIUN_NOTIF_ROCKETCHAT_TOKENFILE`
     * `DIUN_NOTIF_ROCKETCHAT_RENDERATTACHMENT`
     * `DIUN_NOTIF_ROCKETCHAT_TIMEOUT`
+    * `DIUN_NOTIF_ROCKETCHAT_PROXY`
     * `DIUN_NOTIF_ROCKETCHAT_TLSSKIPVERIFY`
     * `DIUN_NOTIF_ROCKETCHAT_TLSCACERTFILES`
     * `DIUN_NOTIF_ROCKETCHAT_TEMPLATETITLE`

--- a/docs/notif/signalrest.md
+++ b/docs/notif/signalrest.md
@@ -27,6 +27,7 @@ You can send Signal notifications via the Signal REST API with the following set
 | `recipients`[^1]   |                                    | A list of recipients, either phone numbers or group ID's                  |
 | `timeout`          | `10s`                              | Timeout specifies a time limit for the request to be made                 |
 | `textMode`         |                                    | Sets the text mode for messages. Use `styled` for formatted text.         |
+| `proxy`            |                                    | HTTP proxy URL to use for requests                                        |
 | `tlsSkipVerify`    | `false`                            | Skip TLS certificate verification                                         |
 | `tlsCaCertFiles`   |                                    | List of paths to custom CA certificate files to use for TLS verification  |
 | `templateBody`[^1] | See [below](#default-templatebody) | [Notification template](../faq.md#notification-template) for message body |
@@ -35,6 +36,7 @@ You can send Signal notifications via the Signal REST API with the following set
     * `DIUN_NOTIF_SIGNALREST_ENDPOINT`
     * `DIUN_NOTIF_SIGNALREST_NUMBER`
     * `DIUN_NOTIF_SIGNALREST_RECIPIENTS_<KEY>`
+    * `DIUN_NOTIF_SIGNALREST_PROXY`
     * `DIUN_NOTIF_SIGNALREST_TLSSKIPVERIFY`
     * `DIUN_NOTIF_SIGNALREST_TLSCACERTFILES`
     * `DIUN_NOTIF_SIGNALREST_TIMEOUT`

--- a/docs/notif/slack.md
+++ b/docs/notif/slack.md
@@ -22,12 +22,14 @@ You can send notifications to your Slack channel using an [incoming webhook URL]
 | `webhookURL`       |                                    | Slack [incoming webhook URL](https://api.slack.com/messaging/webhooks)                                                                |
 | `webhookURLFile`   |                                    | Use content of [secret file](../faq.md#secrets-loaded-from-files-and-trailing-newlines) as webhook URL if `webhookURL` is not defined |
 | `renderFields`     | `true`                             | Render [field objects](https://api.slack.com/messaging/composing/layouts#stack_of_blocks)                                             |
+| `proxy`            |                                    | HTTP proxy URL to use for requests                                                                                                    |
 | `templateBody`[^1] | See [below](#default-templatebody) | [Notification template](../faq.md#notification-template) for message body                                                             |
 
 !!! abstract "Environment variables"
     * `DIUN_NOTIF_SLACK_WEBHOOKURL`
     * `DIUN_NOTIF_SLACK_WEBHOOKURLFILE`
     * `DIUN_NOTIF_SLACK_RENDERFIELDS`
+    * `DIUN_NOTIF_SLACK_PROXY`
     * `DIUN_NOTIF_SLACK_TEMPLATEBODY`
 
 ### Default `templateBody`

--- a/docs/notif/teams.md
+++ b/docs/notif/teams.md
@@ -20,6 +20,7 @@ You can send notifications to your Teams team-channel using an [incoming webhook
 | `webhookURLFile`   |                                    | Use content of [secret file](../faq.md#secrets-loaded-from-files-and-trailing-newlines) as webhook URL if `webhookURL` is not defined           |
 | `renderFacts`      | `true`                             | Render fact objects                                                                                                                             |
 | `timeout`          | `10s`                              | Timeout specifies a time limit for the request to be made                                                                                       |
+| `proxy`            |                                    | HTTP proxy URL to use for requests                                                                                                              |
 | `tlsSkipVerify`    | `false`                            | Skip TLS certificate verification                                                                                                               |
 | `tlsCaCertFiles`   |                                    | List of paths to custom CA certificate files to use for TLS verification                                                                        |
 | `templateBody`[^1] | See [below](#default-templatebody) | [Notification template](../faq.md#notification-template) for message body                                                                       |
@@ -29,6 +30,7 @@ You can send notifications to your Teams team-channel using an [incoming webhook
     * `DIUN_NOTIF_TEAMS_WEBHOOKURLFILE`
     * `DIUN_NOTIF_TEAMS_RENDERFACTS`
     * `DIUN_NOTIF_TEAMS_TIMEOUT`
+    * `DIUN_NOTIF_TEAMS_PROXY`
     * `DIUN_NOTIF_TEAMS_TLSSKIPVERIFY`
     * `DIUN_NOTIF_TEAMS_TLSCACERTFILES`
     * `DIUN_NOTIF_TEAMS_TEMPLATEBODY`

--- a/docs/notif/telegram.md
+++ b/docs/notif/telegram.md
@@ -26,6 +26,7 @@ Multiple chat IDs can be provided in order to deliver notifications to multiple 
 | Name                  | Default                            | Description                                                                                                                          |
 |-----------------------|------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
 | `apiURL`              | `https://api.telegram.org`         | Custom Telegram bot API base URL, for proxies or self-hosted bot API servers                                                         |
+| `proxy`               |                                    | HTTP proxy URL to use for requests                                                                                                   |
 | `token`               |                                    | Telegram bot token                                                                                                                   |
 | `tokenFile`           |                                    | Use content of [secret file](../faq.md#secrets-loaded-from-files-and-trailing-newlines) as Telegram bot token if `token` not defined |
 | `chatIDs`             |                                    | List of [chat IDs](#chatids-format) to send notifications to                                                                         |
@@ -35,6 +36,7 @@ Multiple chat IDs can be provided in order to deliver notifications to multiple 
 
 !!! abstract "Environment variables"
     * `DIUN_NOTIF_TELEGRAM_APIURL`
+    * `DIUN_NOTIF_TELEGRAM_PROXY`
     * `DIUN_NOTIF_TELEGRAM_TOKEN`
     * `DIUN_NOTIF_TELEGRAM_TOKENFILE`
     * `DIUN_NOTIF_TELEGRAM_CHATIDS` (comma separated)

--- a/docs/notif/webhook.md
+++ b/docs/notif/webhook.md
@@ -22,6 +22,7 @@ You can send webhook notifications with the following settings.
 | `method`[^1]     | `GET`   | HTTP method                                                              |
 | `headers`        |         | Map of additional headers to be sent (key is case insensitive)           |
 | `timeout`        | `10s`   | Timeout specifies a time limit for the request to be made                |
+| `proxy`          |         | HTTP proxy URL to use for requests                                       |
 | `tlsSkipVerify`  | `false` | Skip TLS certificate verification                                        |
 | `tlsCaCertFiles` |         | List of paths to custom CA certificate files to use for TLS verification |
 
@@ -30,6 +31,7 @@ You can send webhook notifications with the following settings.
     * `DIUN_NOTIF_WEBHOOK_METHOD`
     * `DIUN_NOTIF_WEBHOOK_HEADERS_<KEY>`
     * `DIUN_NOTIF_WEBHOOK_TIMEOUT`
+    * `DIUN_NOTIF_WEBHOOK_PROXY`
     * `DIUN_NOTIF_WEBHOOK_TLSSKIPVERIFY`
     * `DIUN_NOTIF_WEBHOOK_TLSCACERTFILES`
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -224,6 +224,7 @@ for <code>{{ .Entry.Manifest.Platform }}</code> platform.
 					Telegram: &model.NotifTelegram{
 						APIURL: gotgbot.DefaultAPIURL,
 						Token:  "abcdef123456",
+						Proxy:  "http://proxy.foo.com:3128",
 						ChatIDs: []string{
 							"8547439",
 							"1234567",
@@ -441,6 +442,7 @@ func TestLoadEnv(t *testing.T) {
 				"DIUN_NOTIF_TELEGRAM_TOKEN=abcdef123456",
 				"DIUN_NOTIF_TELEGRAM_CHATIDS=8547439,1234567",
 				"DIUN_NOTIF_TELEGRAM_APIURL=http://telegram-bot-api:8081",
+				"DIUN_NOTIF_TELEGRAM_PROXY=http://proxy.foo.com:3128",
 				"DIUN_PROVIDERS_SWARM=true",
 			},
 			expected: &Config{
@@ -458,6 +460,7 @@ func TestLoadEnv(t *testing.T) {
 						TemplateBody:        model.NotifTelegramDefaultTemplateBody,
 						DisableNotification: new(false),
 						APIURL:              "http://telegram-bot-api:8081",
+						Proxy:               "http://proxy.foo.com:3128",
 					},
 				},
 				Providers: &model.Providers{

--- a/internal/config/fixtures/config.test.yml
+++ b/internal/config/fixtures/config.test.yml
@@ -112,6 +112,7 @@ notif:
     renderFacts: false
   telegram:
     token: abcdef123456
+    proxy: http://proxy.foo.com:3128
     chatIDs:
       - "8547439"
       - "1234567"

--- a/internal/httputil/client.go
+++ b/internal/httputil/client.go
@@ -1,0 +1,40 @@
+package httputil
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+)
+
+func NewClient(proxy string, insecureSkipVerify bool, caCertFiles []string) (http.Client, error) {
+	transport, err := NewTransport(proxy, insecureSkipVerify, caCertFiles)
+	if err != nil {
+		return http.Client{}, err
+	}
+	return http.Client{
+		Transport: transport,
+	}, nil
+}
+
+func NewTransport(proxy string, insecureSkipVerify bool, caCertFiles []string) (*http.Transport, error) {
+	tlsConfig, err := LoadTLSConfig(insecureSkipVerify, caCertFiles)
+	if err != nil {
+		return nil, err
+	}
+
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = tlsConfig
+
+	if proxy != "" {
+		proxyURL, err := url.Parse(proxy)
+		if err != nil {
+			return nil, err
+		}
+		if proxyURL.Scheme == "" || proxyURL.Host == "" {
+			return nil, errors.New("proxy URL must include scheme and host")
+		}
+		transport.Proxy = http.ProxyURL(proxyURL)
+	}
+
+	return transport, nil
+}

--- a/internal/httputil/client_test.go
+++ b/internal/httputil/client_test.go
@@ -1,0 +1,50 @@
+package httputil
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewTransport(t *testing.T) {
+	t.Run("uses default proxy configuration", func(t *testing.T) {
+		transport, err := NewTransport("", false, nil)
+		require.NoError(t, err)
+		require.NotNil(t, transport.Proxy)
+		require.NotNil(t, transport.TLSClientConfig)
+		require.False(t, transport.TLSClientConfig.InsecureSkipVerify)
+	})
+
+	t.Run("with explicit proxy", func(t *testing.T) {
+		transport, err := NewTransport("http://proxy.example.com:3128", false, nil)
+		require.NoError(t, err)
+
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://example.com", nil)
+		require.NoError(t, err)
+
+		proxyURL, err := transport.Proxy(req)
+		require.NoError(t, err)
+		require.Equal(t, "http://proxy.example.com:3128", proxyURL.String())
+	})
+
+	t.Run("invalid proxy URL", func(t *testing.T) {
+		_, err := NewTransport(":", false, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("proxy URL without host", func(t *testing.T) {
+		_, err := NewTransport("proxy.example.com:3128", false, nil)
+		require.Error(t, err)
+	})
+}
+
+func TestNewClient(t *testing.T) {
+	client, err := NewClient("http://proxy.example.com:3128", true, nil)
+	require.NoError(t, err)
+
+	transport, ok := client.Transport.(*http.Transport)
+	require.True(t, ok)
+	require.True(t, transport.TLSClientConfig.InsecureSkipVerify)
+}

--- a/internal/model/notif_apprise.go
+++ b/internal/model/notif_apprise.go
@@ -12,6 +12,7 @@ type NotifApprise struct {
 	Tags           []string       `yaml:"tags,omitempty" json:"tags,omitempty" validate:"omitempty"`
 	URLs           []string       `yaml:"urls,omitempty" json:"urls,omitempty" validate:"omitempty"`
 	Timeout        *time.Duration `yaml:"timeout,omitempty" json:"timeout,omitempty" validate:"required"`
+	Proxy          string         `yaml:"proxy,omitempty" json:"proxy,omitempty" validate:"omitempty,url"`
 	TLSSkipVerify  bool           `yaml:"tlsSkipVerify,omitempty" json:"tlsSkipVerify,omitempty" validate:"omitempty"`
 	TLSCACertFiles []string       `yaml:"tlsCaCertFiles,omitempty" json:"tlsCaCertFiles,omitempty" validate:"omitempty"`
 	TemplateTitle  string         `yaml:"templateTitle,omitempty" json:"templateTitle,omitempty" validate:"required"`

--- a/internal/model/notif_discord.go
+++ b/internal/model/notif_discord.go
@@ -12,6 +12,7 @@ type NotifDiscord struct {
 	RenderEmbeds   *bool          `yaml:"renderEmbeds,omitempty" json:"renderEmbeds,omitempty" validate:"required"`
 	RenderFields   *bool          `yaml:"renderFields,omitempty" json:"renderFields,omitempty" validate:"required"`
 	Timeout        *time.Duration `yaml:"timeout,omitempty" json:"timeout,omitempty" validate:"required"`
+	Proxy          string         `yaml:"proxy,omitempty" json:"proxy,omitempty" validate:"omitempty,url"`
 	TemplateBody   string         `yaml:"templateBody,omitempty" json:"templateBody,omitempty" validate:"required"`
 }
 

--- a/internal/model/notif_elasticsearch.go
+++ b/internal/model/notif_elasticsearch.go
@@ -13,6 +13,7 @@ type NotifElasticsearch struct {
 	Client         string         `yaml:"client,omitempty" json:"client,omitempty" validate:"required"`
 	Index          string         `yaml:"index,omitempty" json:"index,omitempty" validate:"required"`
 	Timeout        *time.Duration `yaml:"timeout,omitempty" json:"timeout,omitempty" validate:"required"`
+	Proxy          string         `yaml:"proxy,omitempty" json:"proxy,omitempty" validate:"omitempty,url"`
 	TLSSkipVerify  bool           `yaml:"tlsSkipVerify,omitempty" json:"tlsSkipVerify,omitempty" validate:"omitempty"`
 	TLSCACertFiles []string       `yaml:"tlsCaCertFiles,omitempty" json:"tlsCaCertFiles,omitempty" validate:"omitempty"`
 }

--- a/internal/model/notif_gotify.go
+++ b/internal/model/notif_gotify.go
@@ -11,6 +11,7 @@ type NotifGotify struct {
 	TokenFile      string         `yaml:"tokenFile,omitempty" json:"tokenFile,omitempty" validate:"omitempty,file"`
 	Priority       int            `yaml:"priority,omitempty" json:"priority,omitempty" validate:"omitempty,min=0"`
 	Timeout        *time.Duration `yaml:"timeout,omitempty" json:"timeout,omitempty" validate:"required"`
+	Proxy          string         `yaml:"proxy,omitempty" json:"proxy,omitempty" validate:"omitempty,url"`
 	TLSSkipVerify  bool           `yaml:"tlsSkipVerify,omitempty" json:"tlsSkipVerify,omitempty" validate:"omitempty"`
 	TLSCACertFiles []string       `yaml:"tlsCaCertFiles,omitempty" json:"tlsCaCertFiles,omitempty" validate:"omitempty"`
 	TemplateTitle  string         `yaml:"templateTitle,omitempty" json:"templateTitle,omitempty" validate:"required"`

--- a/internal/model/notif_ntfy.go
+++ b/internal/model/notif_ntfy.go
@@ -15,6 +15,7 @@ type NotifNtfy struct {
 	Icon           string         `yaml:"icon,omitempty" json:"icon,omitempty" validate:"omitempty"`
 	Click          string         `yaml:"click,omitempty" json:"click,omitempty" validate:"omitempty"`
 	Timeout        *time.Duration `yaml:"timeout,omitempty" json:"timeout,omitempty" validate:"required"`
+	Proxy          string         `yaml:"proxy,omitempty" json:"proxy,omitempty" validate:"omitempty,url"`
 	TLSSkipVerify  bool           `yaml:"tlsSkipVerify,omitempty" json:"tlsSkipVerify,omitempty" validate:"omitempty"`
 	TLSCACertFiles []string       `yaml:"tlsCaCertFiles,omitempty" json:"tlsCaCertFiles,omitempty" validate:"omitempty"`
 	TemplateTitle  string         `yaml:"templateTitle,omitempty" json:"templateTitle,omitempty" validate:"required"`

--- a/internal/model/notif_pushover.go
+++ b/internal/model/notif_pushover.go
@@ -13,6 +13,7 @@ type NotifPushover struct {
 	Priority      int            `yaml:"priority,omitempty" json:"priority,omitempty" validate:"omitempty,min=-2,max=2"`
 	Sound         string         `yaml:"sound,omitempty" json:"sound,omitempty" validate:"omitempty"`
 	Timeout       *time.Duration `yaml:"timeout,omitempty" json:"timeout,omitempty" validate:"required"`
+	Proxy         string         `yaml:"proxy,omitempty" json:"proxy,omitempty" validate:"omitempty,url"`
 	TemplateTitle string         `yaml:"templateTitle,omitempty" json:"templateTitle,omitempty" validate:"required"`
 	TemplateBody  string         `yaml:"templateBody,omitempty" json:"templateBody,omitempty" validate:"required"`
 }

--- a/internal/model/notif_rocketchat.go
+++ b/internal/model/notif_rocketchat.go
@@ -16,6 +16,7 @@ type NotifRocketChat struct {
 	TokenFile        string         `yaml:"tokenFile,omitempty" json:"tokenFile,omitempty" validate:"omitempty,file"`
 	RenderAttachment *bool          `yaml:"renderAttachment,omitempty" json:"renderAttachment,omitempty" validate:"required"`
 	Timeout          *time.Duration `yaml:"timeout,omitempty" json:"timeout,omitempty" validate:"required"`
+	Proxy            string         `yaml:"proxy,omitempty" json:"proxy,omitempty" validate:"omitempty,url"`
 	TLSSkipVerify    bool           `yaml:"tlsSkipVerify,omitempty" json:"tlsSkipVerify,omitempty" validate:"omitempty"`
 	TLSCACertFiles   []string       `yaml:"tlsCaCertFiles,omitempty" json:"tlsCaCertFiles,omitempty" validate:"omitempty"`
 	TemplateTitle    string         `yaml:"templateTitle,omitempty" json:"templateTitle,omitempty" validate:"required"`

--- a/internal/model/notif_signalrest.go
+++ b/internal/model/notif_signalrest.go
@@ -14,6 +14,7 @@ type NotifSignalRest struct {
 	Recipients     []string          `yaml:"recipients,omitempty" json:"recipients,omitempty" validate:"omitempty"`
 	Headers        map[string]string `yaml:"headers,omitempty" json:"headers,omitempty" validate:"omitempty"`
 	Timeout        *time.Duration    `yaml:"timeout,omitempty" json:"timeout,omitempty" validate:"required"`
+	Proxy          string            `yaml:"proxy,omitempty" json:"proxy,omitempty" validate:"omitempty,url"`
 	TLSSkipVerify  bool              `yaml:"tlsSkipVerify,omitempty" json:"tlsSkipVerify,omitempty" validate:"omitempty"`
 	TLSCACertFiles []string          `yaml:"tlsCaCertFiles,omitempty" json:"tlsCaCertFiles,omitempty" validate:"omitempty"`
 	TemplateBody   string            `yaml:"templateBody,omitempty" json:"templateBody,omitempty" validate:"required"`

--- a/internal/model/notif_slack.go
+++ b/internal/model/notif_slack.go
@@ -8,6 +8,7 @@ type NotifSlack struct {
 	WebhookURL     string `yaml:"webhookURL,omitempty" json:"webhookURL,omitempty" validate:"omitempty"`
 	WebhookURLFile string `yaml:"webhookURLFile,omitempty" json:"webhookURLFile,omitempty" validate:"omitempty,file"`
 	RenderFields   *bool  `yaml:"renderFields,omitempty" json:"renderFields,omitempty" validate:"required"`
+	Proxy          string `yaml:"proxy,omitempty" json:"proxy,omitempty" validate:"omitempty,url"`
 	TemplateBody   string `yaml:"templateBody,omitempty" json:"templateBody,omitempty" validate:"required"`
 }
 

--- a/internal/model/notif_teams.go
+++ b/internal/model/notif_teams.go
@@ -13,6 +13,7 @@ type NotifTeams struct {
 	WebhookURLFile string         `yaml:"webhookURLFile,omitempty" json:"webhookURLFile,omitempty" validate:"omitempty,file"`
 	RenderFacts    *bool          `yaml:"renderFacts,omitempty" json:"renderFacts,omitempty" validate:"required"`
 	Timeout        *time.Duration `yaml:"timeout,omitempty" json:"timeout,omitempty" validate:"required"`
+	Proxy          string         `yaml:"proxy,omitempty" json:"proxy,omitempty" validate:"omitempty,url"`
 	TLSSkipVerify  bool           `yaml:"tlsSkipVerify,omitempty" json:"tlsSkipVerify,omitempty" validate:"omitempty"`
 	TLSCACertFiles []string       `yaml:"tlsCaCertFiles,omitempty" json:"tlsCaCertFiles,omitempty" validate:"omitempty"`
 	TemplateBody   string         `yaml:"templateBody,omitempty" json:"templateBody,omitempty" validate:"required"`

--- a/internal/model/notif_telegram.go
+++ b/internal/model/notif_telegram.go
@@ -10,6 +10,7 @@ const NotifTelegramDefaultTemplateBody = `Docker tag {{ if .Entry.Image.HubLink 
 // NotifTelegram holds Telegram notification configuration details
 type NotifTelegram struct {
 	APIURL              string   `yaml:"apiURL,omitempty" json:"apiURL,omitempty" validate:"omitempty,url"`
+	Proxy               string   `yaml:"proxy,omitempty" json:"proxy,omitempty" validate:"omitempty,url"`
 	Token               string   `yaml:"token,omitempty" json:"token,omitempty" validate:"omitempty"`
 	TokenFile           string   `yaml:"tokenFile,omitempty" json:"tokenFile,omitempty" validate:"omitempty,file"`
 	ChatIDs             []string `yaml:"chatIDs,omitempty" json:"chatIDs,omitempty" validate:"omitempty"`

--- a/internal/model/notif_webhook.go
+++ b/internal/model/notif_webhook.go
@@ -10,6 +10,7 @@ type NotifWebhook struct {
 	Method         string            `yaml:"method,omitempty" json:"method,omitempty" validate:"required"`
 	Headers        map[string]string `yaml:"headers,omitempty" json:"headers,omitempty" validate:"omitempty"`
 	Timeout        *time.Duration    `yaml:"timeout,omitempty" json:"timeout,omitempty" validate:"required"`
+	Proxy          string            `yaml:"proxy,omitempty" json:"proxy,omitempty" validate:"omitempty,url"`
 	TLSSkipVerify  bool              `yaml:"tlsSkipVerify,omitempty" json:"tlsSkipVerify,omitempty" validate:"omitempty"`
 	TLSCACertFiles []string          `yaml:"tlsCaCertFiles,omitempty" json:"tlsCaCertFiles,omitempty" validate:"omitempty"`
 }

--- a/internal/notif/apprise/client.go
+++ b/internal/notif/apprise/client.go
@@ -92,14 +92,9 @@ func (c *Client) Send(entry model.NotifEntry) error {
 	timeoutCtx, _ := context.WithTimeoutCause(cancelCtx, *c.cfg.Timeout, errors.WithStack(context.DeadlineExceeded)) //nolint:govet // no need to manually cancel this context as we already rely on parent
 	defer func() { cancel(errors.WithStack(context.Canceled)) }()
 
-	tlsConfig, err := httputil.LoadTLSConfig(c.cfg.TLSSkipVerify, c.cfg.TLSCACertFiles)
+	hc, err := httputil.NewClient(c.cfg.Proxy, c.cfg.TLSSkipVerify, c.cfg.TLSCACertFiles)
 	if err != nil {
-		return errors.Wrap(err, "cannot load TLS configuration for Apprise notifier")
-	}
-	hc := http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: tlsConfig,
-		},
+		return errors.Wrap(err, "cannot create HTTP client for Apprise notifier")
 	}
 	req, err := http.NewRequestWithContext(timeoutCtx, "POST", u.String(), dataBuf)
 	if err != nil {

--- a/internal/notif/discord/client.go
+++ b/internal/notif/discord/client.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/crazy-max/diun/v4/internal/httputil"
 	"github.com/crazy-max/diun/v4/internal/model"
 	"github.com/crazy-max/diun/v4/internal/msg"
 	"github.com/crazy-max/diun/v4/internal/notif/notifier"
@@ -138,7 +139,10 @@ func (c *Client) Send(entry model.NotifEntry) error {
 		return err
 	}
 
-	hc := http.Client{}
+	hc, err := httputil.NewClient(c.cfg.Proxy, false, nil)
+	if err != nil {
+		return errors.Wrap(err, "cannot create HTTP client for Discord notifier")
+	}
 	for attempt := 1; attempt <= discordMaxRateLimitAttempts; attempt++ {
 		cancelCtx, cancel := context.WithCancelCause(context.Background())
 		timeoutCtx, _ := context.WithTimeoutCause(cancelCtx, *c.cfg.Timeout, errors.WithStack(context.DeadlineExceeded)) //nolint:govet // no need to manually cancel this context as we already rely on parent

--- a/internal/notif/elasticsearch/client.go
+++ b/internal/notif/elasticsearch/client.go
@@ -96,14 +96,9 @@ func (c *Client) Send(entry model.NotifEntry) error {
 	timeoutCtx, _ := context.WithTimeoutCause(cancelCtx, *c.cfg.Timeout, errors.WithStack(context.DeadlineExceeded)) //nolint:govet // no need to manually cancel this context as we already rely on parent
 	defer func() { cancel(errors.WithStack(context.Canceled)) }()
 
-	tlsConfig, err := httputil.LoadTLSConfig(c.cfg.TLSSkipVerify, c.cfg.TLSCACertFiles)
+	hc, err := httputil.NewClient(c.cfg.Proxy, c.cfg.TLSSkipVerify, c.cfg.TLSCACertFiles)
 	if err != nil {
-		return errors.Wrap(err, "cannot load TLS configuration for Elasticsearch notifier")
-	}
-	hc := http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: tlsConfig,
-		},
+		return errors.Wrap(err, "cannot create HTTP client for Elasticsearch notifier")
 	}
 
 	req, err := http.NewRequestWithContext(timeoutCtx, "POST", u.String(), bytes.NewBuffer(body))

--- a/internal/notif/gotify/client.go
+++ b/internal/notif/gotify/client.go
@@ -93,14 +93,9 @@ func (c *Client) Send(entry model.NotifEntry) error {
 	timeoutCtx, _ := context.WithTimeoutCause(cancelCtx, *c.cfg.Timeout, errors.WithStack(context.DeadlineExceeded)) //nolint:govet // no need to manually cancel this context as we already rely on parent
 	defer func() { cancel(errors.WithStack(context.Canceled)) }()
 
-	tlsConfig, err := httputil.LoadTLSConfig(c.cfg.TLSSkipVerify, c.cfg.TLSCACertFiles)
+	hc, err := httputil.NewClient(c.cfg.Proxy, c.cfg.TLSSkipVerify, c.cfg.TLSCACertFiles)
 	if err != nil {
-		return errors.Wrap(err, "cannot load TLS configuration for Gotify notifier")
-	}
-	hc := http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: tlsConfig,
-		},
+		return errors.Wrap(err, "cannot create HTTP client for Gotify notifier")
 	}
 	req, err := http.NewRequestWithContext(timeoutCtx, "POST", u.String(), bytes.NewBuffer(jsonBody))
 	if err != nil {

--- a/internal/notif/ntfy/client.go
+++ b/internal/notif/ntfy/client.go
@@ -104,14 +104,9 @@ func (c *Client) Send(entry model.NotifEntry) error {
 	timeoutCtx, _ := context.WithTimeoutCause(cancelCtx, *c.cfg.Timeout, errors.WithStack(context.DeadlineExceeded)) //nolint:govet // no need to manually cancel this context as we already rely on parent
 	defer func() { cancel(errors.WithStack(context.Canceled)) }()
 
-	tlsConfig, err := httputil.LoadTLSConfig(c.cfg.TLSSkipVerify, c.cfg.TLSCACertFiles)
+	hc, err := httputil.NewClient(c.cfg.Proxy, c.cfg.TLSSkipVerify, c.cfg.TLSCACertFiles)
 	if err != nil {
-		return errors.Wrap(err, "cannot load TLS configuration for ntfy notifier")
-	}
-	hc := http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: tlsConfig,
-		},
+		return errors.Wrap(err, "cannot create HTTP client for ntfy notifier")
 	}
 
 	req, err := http.NewRequestWithContext(timeoutCtx, "POST", u.String(), dataBuf)

--- a/internal/notif/pushover/client.go
+++ b/internal/notif/pushover/client.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/crazy-max/diun/v4/internal/httputil"
 	"github.com/crazy-max/diun/v4/internal/model"
 	"github.com/crazy-max/diun/v4/internal/msg"
 	"github.com/crazy-max/diun/v4/internal/notif/notifier"
@@ -94,7 +95,10 @@ func (c *Client) Send(entry model.NotifEntry) error {
 	form.Add("timestamp", strconv.FormatInt(time.Now().Unix(), 10))
 	form.Add("html", "1")
 
-	hc := http.Client{}
+	hc, err := httputil.NewClient(c.cfg.Proxy, false, nil)
+	if err != nil {
+		return errors.Wrap(err, "cannot create HTTP client for Pushover notifier")
+	}
 	req, err := http.NewRequestWithContext(timeoutCtx, "POST", pushoverAPIURL, strings.NewReader(form.Encode()))
 	if err != nil {
 		return err

--- a/internal/notif/rocketchat/client.go
+++ b/internal/notif/rocketchat/client.go
@@ -127,14 +127,9 @@ func (c *Client) Send(entry model.NotifEntry) error {
 	timeoutCtx, _ := context.WithTimeoutCause(cancelCtx, *c.cfg.Timeout, errors.WithStack(context.DeadlineExceeded)) //nolint:govet // no need to manually cancel this context as we already rely on parent
 	defer func() { cancel(errors.WithStack(context.Canceled)) }()
 
-	tlsConfig, err := httputil.LoadTLSConfig(c.cfg.TLSSkipVerify, c.cfg.TLSCACertFiles)
+	hc, err := httputil.NewClient(c.cfg.Proxy, c.cfg.TLSSkipVerify, c.cfg.TLSCACertFiles)
 	if err != nil {
-		return errors.Wrap(err, "cannot load TLS configuration for Rocket.Chat notifier")
-	}
-	hc := http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: tlsConfig,
-		},
+		return errors.Wrap(err, "cannot create HTTP client for Rocket.Chat notifier")
 	}
 
 	req, err := http.NewRequestWithContext(timeoutCtx, "POST", u.String(), dataBuf)

--- a/internal/notif/signalrest/client.go
+++ b/internal/notif/signalrest/client.go
@@ -70,14 +70,9 @@ func (c *Client) Send(entry model.NotifEntry) error {
 	timeoutCtx, _ := context.WithTimeoutCause(cancelCtx, *c.cfg.Timeout, errors.WithStack(context.DeadlineExceeded)) //nolint:govet // no need to manually cancel this context as we already rely on parent
 	defer func() { cancel(errors.WithStack(context.Canceled)) }()
 
-	tlsConfig, err := httputil.LoadTLSConfig(c.cfg.TLSSkipVerify, c.cfg.TLSCACertFiles)
+	hc, err := httputil.NewClient(c.cfg.Proxy, c.cfg.TLSSkipVerify, c.cfg.TLSCACertFiles)
 	if err != nil {
-		return errors.Wrap(err, "cannot load TLS configuration for Signal-REST notifier")
-	}
-	hc := http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: tlsConfig,
-		},
+		return errors.Wrap(err, "cannot create HTTP client for Signal-REST notifier")
 	}
 
 	req, err := http.NewRequestWithContext(timeoutCtx, "POST", c.cfg.Endpoint, bytes.NewBuffer(body))

--- a/internal/notif/slack/client.go
+++ b/internal/notif/slack/client.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/crazy-max/diun/v4/internal/httputil"
 	"github.com/crazy-max/diun/v4/internal/model"
 	"github.com/crazy-max/diun/v4/internal/msg"
 	"github.com/crazy-max/diun/v4/internal/notif/notifier"
@@ -119,8 +120,12 @@ func (c *Client) Send(entry model.NotifEntry) error {
 		},
 	}
 
+	hc, err := httputil.NewClient(c.cfg.Proxy, false, nil)
+	if err != nil {
+		return errors.Wrap(err, "cannot create HTTP client for Slack notifier")
+	}
 	for attempt := 1; attempt <= slackMaxRateLimitAttempts; attempt++ {
-		err = slack.PostWebhook(webhookURL, payload)
+		err = slack.PostWebhookCustomHTTP(webhookURL, &hc, payload)
 		if err == nil {
 			return nil
 		}

--- a/internal/notif/teams/client.go
+++ b/internal/notif/teams/client.go
@@ -119,14 +119,9 @@ func (c *Client) Send(entry model.NotifEntry) error {
 		return err
 	}
 
-	tlsConfig, err := httputil.LoadTLSConfig(c.cfg.TLSSkipVerify, c.cfg.TLSCACertFiles)
+	hc, err := httputil.NewClient(c.cfg.Proxy, c.cfg.TLSSkipVerify, c.cfg.TLSCACertFiles)
 	if err != nil {
-		return errors.Wrap(err, "cannot load TLS configuration for Teams notifier")
-	}
-	hc := http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: tlsConfig,
-		},
+		return errors.Wrap(err, "cannot create HTTP client for Teams notifier")
 	}
 
 	for attempt := 1; attempt <= teamsMaxRateLimitAttempts; attempt++ {

--- a/internal/notif/telegram/client.go
+++ b/internal/notif/telegram/client.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/PaulSonOfLars/gotgbot/v2"
+	"github.com/crazy-max/diun/v4/internal/httputil"
 	"github.com/crazy-max/diun/v4/internal/model"
 	"github.com/crazy-max/diun/v4/internal/msg"
 	"github.com/crazy-max/diun/v4/internal/notif/notifier"
@@ -72,9 +73,14 @@ func (c *Client) Send(entry model.NotifEntry) error {
 		return errors.Wrap(err, "cannot parse chat IDs for Telegram notifier")
 	}
 
+	hc, err := httputil.NewClient(c.cfg.Proxy, false, nil)
+	if err != nil {
+		return errors.Wrap(err, "cannot create HTTP client for Telegram notifier")
+	}
+
 	bot, err := gotgbot.NewBot(token, &gotgbot.BotOpts{
 		BotClient: &gotgbot.BaseBotClient{
-			Client: http.Client{},
+			Client: hc,
 			DefaultRequestOpts: &gotgbot.RequestOpts{
 				Timeout: gotgbot.DefaultTimeout,
 				APIURL:  c.cfg.APIURL,

--- a/internal/notif/webhook/client.go
+++ b/internal/notif/webhook/client.go
@@ -54,14 +54,9 @@ func (c *Client) Send(entry model.NotifEntry) error {
 	timeoutCtx, _ := context.WithTimeoutCause(cancelCtx, *c.cfg.Timeout, errors.WithStack(context.DeadlineExceeded)) //nolint:govet // no need to manually cancel this context as we already rely on parent
 	defer func() { cancel(errors.WithStack(context.Canceled)) }()
 
-	tlsConfig, err := httputil.LoadTLSConfig(c.cfg.TLSSkipVerify, c.cfg.TLSCACertFiles)
+	hc, err := httputil.NewClient(c.cfg.Proxy, c.cfg.TLSSkipVerify, c.cfg.TLSCACertFiles)
 	if err != nil {
-		return errors.Wrap(err, "cannot load TLS configuration for Webhook notifier")
-	}
-	hc := http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: tlsConfig,
-		},
+		return errors.Wrap(err, "cannot create HTTP client for Webhook notifier")
 	}
 
 	req, err := http.NewRequestWithContext(timeoutCtx, c.cfg.Method, c.cfg.Endpoint, bytes.NewBuffer(body))


### PR DESCRIPTION
fixes #1747 

Adds per-notifier HTTP proxy configuration for notification clients that send requests over HTTP.