### PR TITLE
add Teams workflow webhook card support

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -91,6 +91,7 @@ You can override this using the [`--config` flag or `CONFIG` env var with `serve
         webhookURL: https://hooks.slack.com/services/ABCD12EFG/HIJK34LMN/01234567890abcdefghij
       teams:
         webhookURL: https://outlook.office.com/webhook/ABCD12EFG/HIJK34LMN/01234567890abcdefghij
+        cardType: messageCard
       telegram:
         token: aabbccdd:11223344
         chatIDs:

--- a/docs/notif/teams.md
+++ b/docs/notif/teams.md
@@ -1,6 +1,6 @@
 # Teams notifications
 
-You can send notifications to your Teams team-channel using an [incoming webhook URL](https://docs.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/what-are-webhooks-and-connectors).
+You can send notifications to your Teams team-channel using an [incoming webhook URL](https://docs.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/what-are-webhooks-and-connectors) or a Microsoft Teams Workflows webhook URL.
 
 ## Configuration
 
@@ -9,6 +9,7 @@ You can send notifications to your Teams team-channel using an [incoming webhook
     notif:
       teams:
         webhookURL: https://outlook.office.com/webhook/ABCD12EFG/HIJK34LMN/01234567890abcdefghij
+        cardType: messageCard
         renderFacts: true
         templateBody: |
           Docker tag {{ .Entry.Image }} which you subscribed to through {{ .Entry.Provider }} provider has been released.
@@ -16,8 +17,9 @@ You can send notifications to your Teams team-channel using an [incoming webhook
 
 | Name               | Default                            | Description                                                                                                                                     |
 |--------------------|------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|
-| `webhookURL`       |                                    | Teams [incoming webhook URL](https://docs.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/what-are-webhooks-and-connectors) |
+| `webhookURL`       |                                    | Teams [incoming webhook URL](https://docs.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/what-are-webhooks-and-connectors) or Workflows webhook URL              |
 | `webhookURLFile`   |                                    | Use content of [secret file](../faq.md#secrets-loaded-from-files-and-trailing-newlines) as webhook URL if `webhookURL` is not defined           |
+| `cardType`         | `messageCard`                      | Card payload type. Can be `messageCard` or `adaptiveCard`. Use `adaptiveCard` for Teams Workflows webhooks                                    |
 | `renderFacts`      | `true`                             | Render fact objects                                                                                                                             |
 | `timeout`          | `10s`                              | Timeout specifies a time limit for the request to be made                                                                                       |
 | `proxy`            |                                    | HTTP proxy URL to use for requests                                                                                                              |
@@ -28,6 +30,7 @@ You can send notifications to your Teams team-channel using an [incoming webhook
 !!! abstract "Environment variables"
     * `DIUN_NOTIF_TEAMS_WEBHOOKURL`
     * `DIUN_NOTIF_TEAMS_WEBHOOKURLFILE`
+    * `DIUN_NOTIF_TEAMS_CARDTYPE`
     * `DIUN_NOTIF_TEAMS_RENDERFACTS`
     * `DIUN_NOTIF_TEAMS_TIMEOUT`
     * `DIUN_NOTIF_TEAMS_PROXY`
@@ -38,7 +41,18 @@ You can send notifications to your Teams team-channel using an [incoming webhook
 ### Default `templateBody`
 
 ```
-Docker tag {{ if .Entry.Image.HubLink }}[`{{ .Entry.Image }}`]({{ .Entry.Image.HubLink }}){{ else }}`{{ .Entry.Image }}`{{ end }}{{ if (eq .Entry.Status "new") }}newly added{{ else }}updated{{ end }}.
+Docker tag {{ if .Entry.Image.HubLink }}[`{{ .Entry.Image }}`]({{ .Entry.Image.HubLink }}){{ else }}`{{ .Entry.Image }}`{{ end }} {{ if (eq .Entry.Status "new") }}available{{ else }}updated{{ end }}.
+```
+
+### Microsoft Teams Workflows
+
+Microsoft Teams Workflows webhooks can receive Adaptive Card payloads. To use a workflow URL created from the Teams Workflows app, set:
+
+```yaml
+notif:
+  teams:
+    webhookURL: https://prod-00.westeurope.logic.azure.com/workflows/...
+    cardType: adaptiveCard
 ```
 
 ## Sample

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -217,6 +217,7 @@ for <code>{{ .Entry.Manifest.Platform }}</code> platform.
 					},
 					Teams: &model.NotifTeams{
 						WebhookURL:   "https://outlook.office.com/webhook/ABCD12EFG/HIJK34LMN/01234567890abcdefghij",
+						CardType:     model.NotifTeamsCardTypeMessageCard,
 						RenderFacts:  new(false),
 						Timeout:      new(10 * time.Second),
 						TemplateBody: model.NotifTeamsDefaultTemplateBody,

--- a/internal/config/fixtures/config.validate.yml
+++ b/internal/config/fixtures/config.validate.yml
@@ -94,6 +94,7 @@ notif:
     renderFields: false
   teams:
     webhookURL: https://outlook.office.com/webhook/ABCD12EFG/HIJK34LMN/01234567890abcdefghij
+    cardType: adaptiveCard
     renderFacts: true
   telegram:
     token: abcdef123456

--- a/internal/model/notif_teams.go
+++ b/internal/model/notif_teams.go
@@ -7,16 +7,26 @@ import (
 // NotifTeamsDefaultTemplateBody ...
 const NotifTeamsDefaultTemplateBody = "Docker tag {{ if .Entry.Image.HubLink }}[`{{ .Entry.Image }}`]({{ .Entry.Image.HubLink }}){{ else }}`{{ .Entry.Image }}`{{ end }} {{ if (eq .Entry.Status \"new\") }}available{{ else }}updated{{ end }}."
 
+// NotifTeams card type constants
+const (
+	NotifTeamsCardTypeMessageCard  = NotifTeamsCardType("messageCard")
+	NotifTeamsCardTypeAdaptiveCard = NotifTeamsCardType("adaptiveCard")
+)
+
+// NotifTeamsCardType holds Teams card type
+type NotifTeamsCardType string
+
 // NotifTeams holds Teams notification configuration details
 type NotifTeams struct {
-	WebhookURL     string         `yaml:"webhookURL,omitempty" json:"webhookURL,omitempty" validate:"omitempty"`
-	WebhookURLFile string         `yaml:"webhookURLFile,omitempty" json:"webhookURLFile,omitempty" validate:"omitempty,file"`
-	RenderFacts    *bool          `yaml:"renderFacts,omitempty" json:"renderFacts,omitempty" validate:"required"`
-	Timeout        *time.Duration `yaml:"timeout,omitempty" json:"timeout,omitempty" validate:"required"`
-	Proxy          string         `yaml:"proxy,omitempty" json:"proxy,omitempty" validate:"omitempty,url"`
-	TLSSkipVerify  bool           `yaml:"tlsSkipVerify,omitempty" json:"tlsSkipVerify,omitempty" validate:"omitempty"`
-	TLSCACertFiles []string       `yaml:"tlsCaCertFiles,omitempty" json:"tlsCaCertFiles,omitempty" validate:"omitempty"`
-	TemplateBody   string         `yaml:"templateBody,omitempty" json:"templateBody,omitempty" validate:"required"`
+	WebhookURL     string             `yaml:"webhookURL,omitempty" json:"webhookURL,omitempty" validate:"omitempty"`
+	WebhookURLFile string             `yaml:"webhookURLFile,omitempty" json:"webhookURLFile,omitempty" validate:"omitempty,file"`
+	CardType       NotifTeamsCardType `yaml:"cardType,omitempty" json:"cardType,omitempty" validate:"required,oneof=messageCard adaptiveCard"`
+	RenderFacts    *bool              `yaml:"renderFacts,omitempty" json:"renderFacts,omitempty" validate:"required"`
+	Timeout        *time.Duration     `yaml:"timeout,omitempty" json:"timeout,omitempty" validate:"required"`
+	Proxy          string             `yaml:"proxy,omitempty" json:"proxy,omitempty" validate:"omitempty,url"`
+	TLSSkipVerify  bool               `yaml:"tlsSkipVerify,omitempty" json:"tlsSkipVerify,omitempty" validate:"omitempty"`
+	TLSCACertFiles []string           `yaml:"tlsCaCertFiles,omitempty" json:"tlsCaCertFiles,omitempty" validate:"omitempty"`
+	TemplateBody   string             `yaml:"templateBody,omitempty" json:"templateBody,omitempty" validate:"required"`
 }
 
 // GetDefaults gets the default values
@@ -30,5 +40,6 @@ func (s *NotifTeams) GetDefaults() *NotifTeams {
 func (s *NotifTeams) SetDefaults() {
 	s.Timeout = new(10 * time.Second)
 	s.RenderFacts = new(true)
+	s.CardType = NotifTeamsCardTypeMessageCard
 	s.TemplateBody = NotifTeamsDefaultTemplateBody
 }

--- a/internal/notif/teams/client.go
+++ b/internal/notif/teams/client.go
@@ -59,6 +59,48 @@ type Fact struct {
 	Value string `json:"Value"`
 }
 
+type messageCardPayload struct {
+	Type       string     `json:"@type"`
+	Context    string     `json:"@context"`
+	ThemeColor string     `json:"themeColor"`
+	Summary    string     `json:"summary"`
+	Sections   []Sections `json:"sections"`
+}
+
+type adaptiveCardPayload struct {
+	Type        string                   `json:"type"`
+	Attachments []adaptiveCardAttachment `json:"attachments"`
+}
+
+type adaptiveCardAttachment struct {
+	ContentType string              `json:"contentType"`
+	Content     adaptiveCardContent `json:"content"`
+}
+
+type adaptiveCardContent struct {
+	Schema  string                `json:"$schema"`
+	Type    string                `json:"type"`
+	Version string                `json:"version"`
+	Body    []adaptiveCardElement `json:"body"`
+}
+
+type adaptiveCardElement struct {
+	Type     string             `json:"type"`
+	Text     string             `json:"text,omitempty"`
+	Wrap     bool               `json:"wrap,omitempty"`
+	Size     string             `json:"size,omitempty"`
+	Weight   string             `json:"weight,omitempty"`
+	Color    string             `json:"color,omitempty"`
+	IsSubtle bool               `json:"isSubtle,omitempty"`
+	Spacing  string             `json:"spacing,omitempty"`
+	Facts    []adaptiveCardFact `json:"facts,omitempty"`
+}
+
+type adaptiveCardFact struct {
+	Title string `json:"title"`
+	Value string `json:"value"`
+}
+
 // Send creates and sends a webhook notification with an entry
 func (c *Client) Send(entry model.NotifEntry) error {
 	webhookURL, err := secret.GetSecret(c.cfg.WebhookURL, c.cfg.WebhookURLFile)
@@ -80,41 +122,7 @@ func (c *Client) Send(entry model.NotifEntry) error {
 		return err
 	}
 
-	themeColor := "68CA00"
-	if entry.Status == model.ImageStatusUpdate {
-		themeColor = "0076D7"
-	}
-
-	var facts []Fact
-	if *c.cfg.RenderFacts {
-		facts = []Fact{
-			{"Hostname", c.meta.Hostname},
-			{"Provider", entry.Provider},
-			{"Created", entry.Manifest.Created.Format("Jan 02, 2006 15:04:05 UTC")},
-			{"Digest", entry.Manifest.Digest.String()},
-			{"Platform", entry.Manifest.Platform},
-		}
-	}
-
-	jsonBody, err := json.Marshal(struct {
-		Type       string     `json:"@type"`
-		Context    string     `json:"@context"`
-		ThemeColor string     `json:"themeColor"`
-		Summary    string     `json:"summary"`
-		Sections   []Sections `json:"sections"`
-	}{
-		Type:       "MessageCard",
-		Context:    "https://schema.org/extensions",
-		ThemeColor: themeColor,
-		Summary:    string(body),
-		Sections: []Sections{
-			{
-				ActivityTitle:    string(body),
-				ActivitySubtitle: fmt.Sprintf("%s © %d %s %s", c.meta.Author, time.Now().Year(), c.meta.Name, c.meta.Version),
-				Facts:            facts,
-			},
-		},
-	})
+	jsonBody, err := c.payload(entry, string(body))
 	if err != nil {
 		return err
 	}
@@ -165,6 +173,102 @@ func (c *Client) Send(entry model.NotifEntry) error {
 	}
 
 	return nil
+}
+
+func (c *Client) payload(entry model.NotifEntry, body string) ([]byte, error) {
+	facts := c.facts(entry)
+	if c.cfg.CardType == model.NotifTeamsCardTypeAdaptiveCard {
+		return json.Marshal(c.adaptiveCardPayload(entry, body, facts))
+	}
+	return json.Marshal(c.messageCardPayload(entry, body, facts))
+}
+
+func (c *Client) facts(entry model.NotifEntry) []Fact {
+	if !*c.cfg.RenderFacts {
+		return nil
+	}
+
+	return []Fact{
+		{"Hostname", c.meta.Hostname},
+		{"Provider", entry.Provider},
+		{"Created", entry.Manifest.Created.Format("Jan 02, 2006 15:04:05 UTC")},
+		{"Digest", entry.Manifest.Digest.String()},
+		{"Platform", entry.Manifest.Platform},
+	}
+}
+
+func (c *Client) messageCardPayload(entry model.NotifEntry, body string, facts []Fact) messageCardPayload {
+	themeColor := "68CA00"
+	if entry.Status == model.ImageStatusUpdate {
+		themeColor = "0076D7"
+	}
+
+	return messageCardPayload{
+		Type:       "MessageCard",
+		Context:    "https://schema.org/extensions",
+		ThemeColor: themeColor,
+		Summary:    body,
+		Sections: []Sections{
+			{
+				ActivityTitle:    body,
+				ActivitySubtitle: fmt.Sprintf("%s © %d %s %s", c.meta.Author, time.Now().Year(), c.meta.Name, c.meta.Version),
+				Facts:            facts,
+			},
+		},
+	}
+}
+
+func (c *Client) adaptiveCardPayload(entry model.NotifEntry, body string, facts []Fact) adaptiveCardPayload {
+	color := "Good"
+	if entry.Status == model.ImageStatusUpdate {
+		color = "Accent"
+	}
+
+	elements := []adaptiveCardElement{
+		{
+			Type:   "TextBlock",
+			Text:   body,
+			Wrap:   true,
+			Weight: "Bolder",
+			Color:  color,
+		},
+	}
+	if len(facts) > 0 {
+		adaptiveFacts := make([]adaptiveCardFact, 0, len(facts))
+		for _, fact := range facts {
+			adaptiveFacts = append(adaptiveFacts, adaptiveCardFact{
+				Title: fact.Name,
+				Value: fact.Value,
+			})
+		}
+		elements = append(elements, adaptiveCardElement{
+			Type:  "FactSet",
+			Facts: adaptiveFacts,
+		})
+	}
+	elements = append(elements, adaptiveCardElement{
+		Type:     "TextBlock",
+		Text:     fmt.Sprintf("%s © %d %s %s", c.meta.Author, time.Now().Year(), c.meta.Name, c.meta.Version),
+		Wrap:     true,
+		Size:     "Small",
+		IsSubtle: true,
+		Spacing:  "Small",
+	})
+
+	return adaptiveCardPayload{
+		Type: "message",
+		Attachments: []adaptiveCardAttachment{
+			{
+				ContentType: "application/vnd.microsoft.card.adaptive",
+				Content: adaptiveCardContent{
+					Schema:  "http://adaptivecards.io/schemas/adaptive-card.json",
+					Type:    "AdaptiveCard",
+					Version: "1.2",
+					Body:    elements,
+				},
+			},
+		},
+	}
 }
 
 func teamsRateLimited(resp *http.Response, body []byte) bool {

--- a/internal/notif/teams/client_test.go
+++ b/internal/notif/teams/client_test.go
@@ -19,13 +19,7 @@ func TestSendPostsMessageCard(t *testing.T) {
 	var gotMethod string
 	var gotUserAgent string
 	var gotContentType string
-	var gotPayload struct {
-		Type       string     `json:"@type"`
-		Context    string     `json:"@context"`
-		ThemeColor string     `json:"themeColor"`
-		Summary    string     `json:"summary"`
-		Sections   []Sections `json:"sections"`
-	}
+	var gotPayload messageCardPayload
 	var gotPayloadErr error
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -60,6 +54,66 @@ func TestSendPostsMessageCard(t *testing.T) {
 		{Name: "Digest", Value: "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"},
 		{Name: "Platform", Value: "linux/amd64"},
 	}, section.Facts)
+}
+
+func TestSendPostsAdaptiveCard(t *testing.T) {
+	var gotMethod string
+	var gotUserAgent string
+	var gotContentType string
+	var gotPayload adaptiveCardPayload
+	var gotPayloadErr error
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotUserAgent = r.Header.Get("User-Agent")
+		gotContentType = r.Header.Get("Content-Type")
+		gotPayloadErr = json.NewDecoder(r.Body).Decode(&gotPayload)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	err := newTestClientWithCardType(ts.URL, model.NotifTeamsCardTypeAdaptiveCard).Send(testEntry(t))
+	require.NoError(t, err)
+	require.NoError(t, gotPayloadErr)
+
+	assert.Equal(t, http.MethodPost, gotMethod)
+	assert.Equal(t, "diun-test", gotUserAgent)
+	assert.Equal(t, "application/json", gotContentType)
+	assert.Equal(t, "message", gotPayload.Type)
+	require.Len(t, gotPayload.Attachments, 1)
+
+	attachment := gotPayload.Attachments[0]
+	assert.Equal(t, "application/vnd.microsoft.card.adaptive", attachment.ContentType)
+	assert.Equal(t, "http://adaptivecards.io/schemas/adaptive-card.json", attachment.Content.Schema)
+	assert.Equal(t, "AdaptiveCard", attachment.Content.Type)
+	assert.Equal(t, "1.2", attachment.Content.Version)
+	require.Len(t, attachment.Content.Body, 3)
+
+	assert.Equal(t, adaptiveCardElement{
+		Type:   "TextBlock",
+		Text:   "file update",
+		Wrap:   true,
+		Weight: "Bolder",
+		Color:  "Accent",
+	}, attachment.Content.Body[0])
+	assert.Equal(t, adaptiveCardElement{
+		Type: "FactSet",
+		Facts: []adaptiveCardFact{
+			{Title: "Hostname", Value: "node-1"},
+			{Title: "Provider", Value: "file"},
+			{Title: "Created", Value: "May 24, 2026 12:34:56 UTC"},
+			{Title: "Digest", Value: "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"},
+			{Title: "Platform", Value: "linux/amd64"},
+		},
+	}, attachment.Content.Body[1])
+	assert.Equal(t, adaptiveCardElement{
+		Type:     "TextBlock",
+		Text:     fmt.Sprintf("CrazyMax © %d Diun 4.0.0", time.Now().Year()),
+		Wrap:     true,
+		Size:     "Small",
+		IsSubtle: true,
+		Spacing:  "Small",
+	}, attachment.Content.Body[2])
 }
 
 func TestSendReturnsTeamsErrorResponse(t *testing.T) {
@@ -123,9 +177,14 @@ func TestSendStopsAfterTeamsRateLimitAttempts(t *testing.T) {
 }
 
 func newTestClient(webhookURL string) *Client {
+	return newTestClientWithCardType(webhookURL, model.NotifTeamsCardTypeMessageCard)
+}
+
+func newTestClientWithCardType(webhookURL string, cardType model.NotifTeamsCardType) *Client {
 	return &Client{
 		cfg: &model.NotifTeams{
 			WebhookURL:   webhookURL,
+			CardType:     cardType,
 			RenderFacts:  new(true),
 			Timeout:      new(2 * time.Second),
 			TemplateBody: "{{ .Entry.Provider }} {{ .Entry.Status }}",


### PR DESCRIPTION
fixes https://github.com/crazy-max/diun/issues/1215

Adds support for Microsoft Teams Workflows webhooks by allowing the Teams notifier to send Adaptive Card payloads.

The Teams notifier now has a `cardType` option that defaults to `messageCard` for existing Office 365 connector behavior and supports `adaptiveCard` for Teams Workflows webhook URLs.

Microsoft is retiring Office 365 connectors, and Teams Workflows expects a different webhook payload shape than the legacy MessageCard format. This keeps existing configurations working while giving users an explicit migration path.