### PR TITLE
treat configured scheduler as healthy during startup

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -164,12 +164,16 @@ func (di *Diun) Start(ctx context.Context) error {
 		}()
 	}
 
+	if len(di.cfg.Watch.Schedule) > 0 {
+		di.grpc.SetHealthStatus(grpc.HealthServiceScheduler, healthpb.HealthCheckResponse_SERVING)
+	}
+	di.grpc.SetHealthStatus("", healthpb.HealthCheckResponse_SERVING)
+
 	if *di.cfg.Watch.RunOnStartup {
 		di.Run()
 	}
 
 	if len(di.cfg.Watch.Schedule) == 0 {
-		di.grpc.SetHealthStatus("", healthpb.HealthCheckResponse_SERVING)
 		return nil
 	}
 	di.jobID, err = di.cron.AddJobWithJitter(di.cfg.Watch.Schedule, di, *di.cfg.Watch.Jitter)
@@ -179,8 +183,6 @@ func (di *Diun) Start(ctx context.Context) error {
 	log.Info().Msgf("Cron initialized with schedule %s", di.cfg.Watch.Schedule)
 
 	di.cron.Start()
-	di.grpc.SetHealthStatus(grpc.HealthServiceScheduler, healthpb.HealthCheckResponse_SERVING)
-	di.grpc.SetHealthStatus("", healthpb.HealthCheckResponse_SERVING)
 	log.Info().Msgf("Next run in %s (%s)",
 		carbon.CreateFromStdTime(di.cron.Entry(di.jobID).Next).DiffAbsInString(),
 		di.cron.Entry(di.jobID).Next)


### PR DESCRIPTION
This fixes the Diun healthcheck so a configured scheduler is reported as healthy once the runtime services are ready, even when the cron interval is long or `runOnStartup` is still doing registry work.

For example a six-hour cron schedule is a normal healthy configuration, so the healthcheck should not report the scheduler as unhealthy just because the next scheduled run is far away or startup work has not finished yet.