### PR TITLE
Improve watch_repo with newer_only option

### DIFF
--- a/docs/config/defaults.md
+++ b/docs/config/defaults.md
@@ -40,6 +40,40 @@ with this setting). (default `false`)
 !!! abstract "Environment variables"
     * `DIUN_DEFAULTS_WATCHREPO`
 
+### `watchNewerOnly`
+
+When `watchRepo` is enabled, only notify for tags whose semantic version is
+**strictly greater** than the current image tag. Tags that cannot be parsed as a
+semantic version (e.g. `latest`, `edge`, date-based tags) are silently ignored.
+(default `false`)
+
+!!! warning
+    Only works if `watchRepo` is enabled and the current image tag is a valid
+    semantic version (e.g. `1.5.0`, `v2.3.1`).
+
+!!! example "Config file"
+    ```yaml
+    defaults:
+      watchNewerOnly: true
+    ```
+
+!!! abstract "Environment variables"
+    * `DIUN_DEFAULTS_WATCHNEWERONLY`
+
+### `includePrereleases`
+
+When `watchNewerOnly` is enabled, also include pre-release tags (e.g. `-rc.1`,
+`-alpha`, `-beta`) that are newer than the current version. (default `false`)
+
+!!! example "Config file"
+    ```yaml
+    defaults:
+      includePrereleases: false
+    ```
+
+!!! abstract "Environment variables"
+    * `DIUN_DEFAULTS_INCLUDEPRERELEASES`
+
 ### `notifyOn`
 
 List of status to be notified. Can be one of `new` or `update`.

--- a/docs/providers/containerd.md
+++ b/docs/providers/containerd.md
@@ -110,19 +110,21 @@ Include stopped containers too (default `false`).
 
 You can configure more finely the way to analyze the image of your container through containerd labels:
 
-| Name                | Default                        | Description                                                                                                                                             |
-|---------------------|--------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `diun.enable`       |                                | Set to true to enable image analysis of this container                                                                                                  |
-| `diun.regopt`       |                                | [Registry options](../config/regopts.md) name to use                                                                                                    |
-| `diun.watch_repo`   | `false`                        | Watch all tags of this container image ([be careful](../faq.md#docker-hub-rate-limits) with this setting)                                               |
-| `diun.notify_on`    | `new;update`                   | Semicolon separated list of status to be notified: `new`, `update`                                                                                      |
-| `diun.sort_tags`    | `reverse`                      | [Sort tags method](../faq.md#tags-sorting-when-using-watch_repo) if `diun.watch_repo` enabled. One of `default`, `reverse`, `semver`, `lexicographical` |
-| `diun.max_tags`     | `0`                            | Maximum number of tags to watch if `diun.watch_repo` enabled. `0` means all of them                                                                     |
-| `diun.include_tags` |                                | Semicolon separated list of regular expressions to include tags. If set, replaces `defaults.includeTags` for this image. Can be useful if you enable `diun.watch_repo` |
-| `diun.exclude_tags` |                                | Semicolon separated list of regular expressions to exclude tags. If set, replaces `defaults.excludeTags` for this image. Can be useful if you enable `diun.watch_repo` |
-| `diun.hub_link`     | _automatic_                    | Set registry hub link for this image                                                                                                                    |
-| `diun.platform`     | _automatic_                    | Platform to use (e.g. `linux/amd64`)                                                                                                                    |
-| `diun.metadata.*`   | See [below](#default-metadata) | Additional metadata that can be used in [notification template](../faq.md#notification-template) (e.g. `diun.metadata.foo=bar`)                         |
+| Name                        | Default                        | Description                                                                                                                                             |
+|-----------------------------|--------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `diun.enable`               |                                | Set to true to enable image analysis of this container                                                                                                  |
+| `diun.regopt`               |                                | [Registry options](../config/regopts.md) name to use                                                                                                    |
+| `diun.watch_repo`           | `false`                        | Watch all tags of this container image ([be careful](../faq.md#docker-hub-rate-limits) with this setting)                                               |
+| `diun.watch_newer_only`     | `false`                        | Only notify for tags whose semver is strictly greater than the current tag. Non-semver tags (e.g. `latest`) are ignored. Requires `diun.watch_repo`      |
+| `diun.include_prereleases`  | `false`                        | When `diun.watch_newer_only` is enabled, also include pre-release tags (e.g. `-rc.1`, `-alpha`). Requires `diun.watch_newer_only`                       |
+| `diun.notify_on`            | `new;update`                   | Semicolon separated list of status to be notified: `new`, `update`                                                                                      |
+| `diun.sort_tags`            | `reverse`                      | [Sort tags method](../faq.md#tags-sorting-when-using-watch_repo) if `diun.watch_repo` enabled. One of `default`, `reverse`, `semver`, `lexicographical` |
+| `diun.max_tags`             | `0`                            | Maximum number of tags to watch if `diun.watch_repo` enabled. `0` means all of them                                                                     |
+| `diun.include_tags`         |                                | Semicolon separated list of regular expressions to include tags. If set, replaces `defaults.includeTags` for this image. Can be useful if you enable `diun.watch_repo` |
+| `diun.exclude_tags`         |                                | Semicolon separated list of regular expressions to exclude tags. If set, replaces `defaults.excludeTags` for this image. Can be useful if you enable `diun.watch_repo` |
+| `diun.hub_link`             | _automatic_                    | Set registry hub link for this image                                                                                                                    |
+| `diun.platform`             | _automatic_                    | Platform to use (e.g. `linux/amd64`)                                                                                                                    |
+| `diun.metadata.*`           | See [below](#default-metadata) | Additional metadata that can be used in [notification template](../faq.md#notification-template) (e.g. `diun.metadata.foo=bar`)                         |
 
 ## Default metadata
 

--- a/docs/providers/docker.md
+++ b/docs/providers/docker.md
@@ -177,19 +177,21 @@ Include created and exited containers too (default `false`).
 
 You can configure more finely the way to analyze the image of your container through Docker labels:
 
-| Name                | Default                        | Description                                                                                                                                             |
-|---------------------|--------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `diun.enable`       |                                | Set to true to enable image analysis of this container                                                                                                  |
-| `diun.regopt`       |                                | [Registry options](../config/regopts.md) name to use                                                                                                    |
-| `diun.watch_repo`   | `false`                        | Watch all tags of this container image ([be careful](../faq.md#docker-hub-rate-limits) with this setting)                                               |
-| `diun.notify_on`    | `new;update`                   | Semicolon separated list of status to be notified: `new`, `update`                                                                                      |
-| `diun.sort_tags`    | `reverse`                      | [Sort tags method](../faq.md#tags-sorting-when-using-watch_repo) if `diun.watch_repo` enabled. One of `default`, `reverse`, `semver`, `lexicographical` |
-| `diun.max_tags`     | `0`                            | Maximum number of tags to watch if `diun.watch_repo` enabled. `0` means all of them                                                                     |
-| `diun.include_tags` |                                | Semicolon separated list of regular expressions to include tags. If set, replaces `defaults.includeTags` for this image. Can be useful if you enable `diun.watch_repo` |
-| `diun.exclude_tags` |                                | Semicolon separated list of regular expressions to exclude tags. If set, replaces `defaults.excludeTags` for this image. Can be useful if you enable `diun.watch_repo` |
-| `diun.hub_link`     | _automatic_                    | Set registry hub link for this image                                                                                                                    |
-| `diun.platform`     | _automatic_                    | Platform to use (e.g. `linux/amd64`)                                                                                                                    |
-| `diun.metadata.*`   | See [below](#default-metadata) | Additional metadata that can be used in [notification template](../faq.md#notification-template) (e.g. `diun.metadata.foo=bar`)                         |
+| Name                      | Default                        | Description                                                                                                                                             |
+|---------------------------|--------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `diun.enable`             |                                | Set to true to enable image analysis of this container                                                                                                  |
+| `diun.regopt`             |                                | [Registry options](../config/regopts.md) name to use                                                                                                    |
+| `diun.watch_repo`         | `false`                        | Watch all tags of this container image ([be careful](../faq.md#docker-hub-rate-limits) with this setting)                                               |
+| `diun.watch_newer_only`   | `false`                        | Only notify for tags whose semver is strictly greater than the current tag. Non-semver tags (e.g. `latest`) are ignored. Requires `diun.watch_repo`      |
+| `diun.include_prereleases`| `false`                        | When `diun.watch_newer_only` is enabled, also include pre-release tags (e.g. `-rc.1`, `-alpha`). Requires `diun.watch_newer_only`                       |
+| `diun.notify_on`          | `new;update`                   | Semicolon separated list of status to be notified: `new`, `update`                                                                                      |
+| `diun.sort_tags`          | `reverse`                      | [Sort tags method](../faq.md#tags-sorting-when-using-watch_repo) if `diun.watch_repo` enabled. One of `default`, `reverse`, `semver`, `lexicographical` |
+| `diun.max_tags`           | `0`                            | Maximum number of tags to watch if `diun.watch_repo` enabled. `0` means all of them                                                                     |
+| `diun.include_tags`       |                                | Semicolon separated list of regular expressions to include tags. If set, replaces `defaults.includeTags` for this image. Can be useful if you enable `diun.watch_repo` |
+| `diun.exclude_tags`       |                                | Semicolon separated list of regular expressions to exclude tags. If set, replaces `defaults.excludeTags` for this image. Can be useful if you enable `diun.watch_repo` |
+| `diun.hub_link`           | _automatic_                    | Set registry hub link for this image                                                                                                                    |
+| `diun.platform`           | _automatic_                    | Platform to use (e.g. `linux/amd64`)                                                                                                                    |
+| `diun.metadata.*`         | See [below](#default-metadata) | Additional metadata that can be used in [notification template](../faq.md#notification-template) (e.g. `diun.metadata.foo=bar`)                         |
 
 ## Default metadata
 

--- a/docs/providers/dockerfile.md
+++ b/docs/providers/dockerfile.md
@@ -107,15 +107,17 @@ List of path patterns with [matching and globbing supporting patterns](https://g
 
 The following annotations can be added as comments before the target instruction to customize the image analysis:
 
-| Name                | Default      | Description                                                                                                                                             |
-|---------------------|--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `diun.regopt`       |              | [Registry options](../config/regopts.md) name to use                                                                                                    |
-| `diun.watch_repo`   | `false`      | Watch all tags of this image                                                                                                                            |
-| `diun.notify_on`    | `new;update` | Semicolon separated list of status to be notified: `new`, `update`                                                                                      |
-| `diun.sort_tags`    | `reverse`    | [Sort tags method](../faq.md#tags-sorting-when-using-watch_repo) if `diun.watch_repo` enabled. One of `default`, `reverse`, `semver`, `lexicographical` |
-| `diun.max_tags`     | `0`          | Maximum number of tags to watch if `watch_repo` enabled. `0` means all of them                                                                          |
-| `diun.include_tags` |              | Semicolon separated list of regular expressions to include tags. If set, replaces `defaults.includeTags` for this image. Can be useful if you enable `diun.watch_repo` |
-| `diun.exclude_tags` |              | Semicolon separated list of regular expressions to exclude tags. If set, replaces `defaults.excludeTags` for this image. Can be useful if you enable `diun.watch_repo` |
-| `diun.hub_link`     | _automatic_  | Set registry hub link for this image                                                                                                                    |
-| `diun.platform`     | _automatic_  | Platform to use (e.g. `linux/amd64`)                                                                                                                    |
-| `diun.metadata.*`   |              | Additional metadata that can be used in [notification template](../faq.md#notification-template) (e.g. `metadata.foo=bar`)                              |
+| Name                        | Default      | Description                                                                                                                                             |
+|-----------------------------|--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `diun.regopt`               |              | [Registry options](../config/regopts.md) name to use                                                                                                    |
+| `diun.watch_repo`           | `false`      | Watch all tags of this image                                                                                                                            |
+| `diun.watch_newer_only`     | `false`      | Only notify for tags whose semver is strictly greater than the current tag. Non-semver tags (e.g. `latest`) are ignored. Requires `diun.watch_repo`     |
+| `diun.include_prereleases`  | `false`      | When `diun.watch_newer_only` is enabled, also include pre-release tags (e.g. `-rc.1`, `-alpha`). Requires `diun.watch_newer_only`                      |
+| `diun.notify_on`            | `new;update` | Semicolon separated list of status to be notified: `new`, `update`                                                                                      |
+| `diun.sort_tags`            | `reverse`    | [Sort tags method](../faq.md#tags-sorting-when-using-watch_repo) if `diun.watch_repo` enabled. One of `default`, `reverse`, `semver`, `lexicographical` |
+| `diun.max_tags`             | `0`          | Maximum number of tags to watch if `watch_repo` enabled. `0` means all of them                                                                          |
+| `diun.include_tags`         |              | Semicolon separated list of regular expressions to include tags. If set, replaces `defaults.includeTags` for this image. Can be useful if you enable `diun.watch_repo` |
+| `diun.exclude_tags`         |              | Semicolon separated list of regular expressions to exclude tags. If set, replaces `defaults.excludeTags` for this image. Can be useful if you enable `diun.watch_repo` |
+| `diun.hub_link`             | _automatic_  | Set registry hub link for this image                                                                                                                    |
+| `diun.platform`             | _automatic_  | Platform to use (e.g. `linux/amd64`)                                                                                                                    |
+| `diun.metadata.*`            |              | Additional metadata that can be used in [notification template](../faq.md#notification-template) (e.g. `metadata.foo=bar`)                              |

--- a/docs/providers/file.md
+++ b/docs/providers/file.md
@@ -175,18 +175,20 @@ Defines the path to the directory that contains the [configuration files](#yaml-
 
 The configuration file(s) defines a slice of images to analyze with the following fields:
 
-| Name               | Default      | Description                                                                                                                                             |
-|--------------------|--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `name`             | `latest`     | Docker image name to watch using `registry/path:tag` format. If registry omitted, `docker.io` will be used and if tag omitted, `latest` will be used    |
-| `regopt`           |              | [Registry options](../config/regopts.md) name to use                                                                                                    |
-| `watch_repo`       | `false`      | Watch all tags of this image ([be careful](../faq.md#docker-hub-rate-limits) with this setting)                                                         |
-| `notify_on`        | `new;update` | Semicolon separated list of status to be notified: `new`, `update`                                                                                      |
-| `sort_tags`        | `reverse`    | [Sort tags method](../faq.md#tags-sorting-when-using-watch_repo) if `diun.watch_repo` enabled. One of `default`, `reverse`, `semver`, `lexicographical` |
-| `max_tags`         | `0`          | Maximum number of tags to watch if `watch_repo` enabled. `0` means all of them                                                                          |
-| `include_tags`     |              | List of regular expressions to include tags. If set, replaces `defaults.includeTags` for this image. Can be useful if you enable `watch_repo`           |
-| `exclude_tags`     |              | List of regular expressions to exclude tags. If set, merges with `defaults.excludeTags` for this image. Can be useful if you enable `watch_repo`        |
-| `hub_link`         | _automatic_  | Set registry hub link for this image                                                                                                                    |
-| `platform.os`      | _automatic_  | Operating system to use as custom platform                                                                                                              |
-| `platform.arch`    | _automatic_  | CPU architecture to use as custom platform                                                                                                              |
-| `platform.variant` | _automatic_  | Variant of the CPU to use as custom platform                                                                                                            |
-| `metadata.*`       |              | Additional metadata that can be used in [notification template](../faq.md#notification-template) (e.g. `metadata.foo=bar`)                              |
+| Name                  | Default      | Description                                                                                                                                             |
+|-----------------------|--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `name`                | `latest`     | Docker image name to watch using `registry/path:tag` format. If registry omitted, `docker.io` will be used and if tag omitted, `latest` will be used    |
+| `regopt`              |              | [Registry options](../config/regopts.md) name to use                                                                                                    |
+| `watch_repo`          | `false`      | Watch all tags of this image ([be careful](../faq.md#docker-hub-rate-limits) with this setting)                                                         |
+| `watch_newer_only`    | `false`      | Only notify for tags whose semver is strictly greater than the current tag. Non-semver tags (e.g. `latest`) are ignored. Requires `watch_repo`           |
+| `include_prereleases` | `false`      | When `watch_newer_only` is enabled, also include pre-release tags (e.g. `-rc.1`, `-alpha`). Requires `watch_newer_only`                                 |
+| `notify_on`           | `new;update` | Semicolon separated list of status to be notified: `new`, `update`                                                                                      |
+| `sort_tags`           | `reverse`    | [Sort tags method](../faq.md#tags-sorting-when-using-watch_repo) if `diun.watch_repo` enabled. One of `default`, `reverse`, `semver`, `lexicographical` |
+| `max_tags`            | `0`          | Maximum number of tags to watch if `watch_repo` enabled. `0` means all of them                                                                          |
+| `include_tags`        |              | List of regular expressions to include tags. If set, replaces `defaults.includeTags` for this image. Can be useful if you enable `watch_repo`           |
+| `exclude_tags`        |              | List of regular expressions to exclude tags. If set, merges with `defaults.excludeTags` for this image. Can be useful if you enable `watch_repo`        |
+| `hub_link`            | _automatic_  | Set registry hub link for this image                                                                                                                    |
+| `platform.os`         | _automatic_  | Operating system to use as custom platform                                                                                                              |
+| `platform.arch`       | _automatic_  | CPU architecture to use as custom platform                                                                                                              |
+| `platform.variant`    | _automatic_  | Variant of the CPU to use as custom platform                                                                                                            |
+| `metadata.*`          |              | Additional metadata that can be used in [notification template](../faq.md#notification-template) (e.g. `metadata.foo=bar`)                              |

--- a/docs/providers/kubernetes.md
+++ b/docs/providers/kubernetes.md
@@ -304,19 +304,21 @@ annotation will be ignored (default `false`).
 You can configure more finely the way to analyze the image of your pods through
 Kubernetes annotations:
 
-| Name                | Default                        | Description                                                                                                                                             |
-|---------------------|--------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `diun.enable`       |                                | Set to true to enable image analysis of this pod                                                                                                        |
-| `diun.regopt`       |                                | [Registry options](../config/regopts.md) name to use                                                                                                    |
-| `diun.watch_repo`   | `false`                        | Watch all tags of this pod image ([be careful](../faq.md#docker-hub-rate-limits) with this setting)                                                     |
-| `diun.notify_on`    | `new;update`                   | Semicolon separated list of status to be notified: `new`, `update`.                                                                                     |
-| `diun.sort_tags`    | `reverse`                      | [Sort tags method](../faq.md#tags-sorting-when-using-watch_repo) if `diun.watch_repo` enabled. One of `default`, `reverse`, `semver`, `lexicographical` |
-| `diun.max_tags`     | `0`                            | Maximum number of tags to watch if `diun.watch_repo` enabled. `0` means all of them                                                                     |
-| `diun.include_tags` |                                | Semicolon separated list of regular expressions to include tags. If set, replaces `defaults.includeTags` for this image. Can be useful if you enable `diun.watch_repo` |
-| `diun.exclude_tags` |                                | Semicolon separated list of regular expressions to exclude tags. If set, replaces `defaults.excludeTags` for this image. Can be useful if you enable `diun.watch_repo` |
-| `diun.hub_link`     | _automatic_                    | Set registry hub link for this image                                                                                                                    |
-| `diun.platform`     | _automatic_                    | Platform to use (e.g. `linux/amd64`)                                                                                                                    |
-| `diun.metadata.*`   | See [below](#default-metadata) | Additional metadata that can be used in [notification template](../faq.md#notification-template) (e.g. `diun.metadata.foo=bar`)                         |
+| Name                      | Default                        | Description                                                                                                                                             |
+|---------------------------|--------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `diun.enable`             |                                | Set to true to enable image analysis of this container                                                                                                  |
+| `diun.regopt`             |                                | [Registry options](../config/regopts.md) name to use                                                                                                    |
+| `diun.watch_repo`         | `false`                        | Watch all tags of this container image ([be careful](../faq.md#docker-hub-rate-limits) with this setting)                                               |
+| `diun.watch_newer_only`   | `false`                        | Only notify for tags whose semver is strictly greater than the current tag. Non-semver tags (e.g. `latest`) are ignored. Requires `diun.watch_repo`      |
+| `diun.include_prereleases`| `false`                        | When `diun.watch_newer_only` is enabled, also include pre-release tags (e.g. `-rc.1`, `-alpha`). Requires `diun.watch_newer_only`                       |
+| `diun.notify_on`          | `new;update`                   | Semicolon separated list of status to be notified: `new`, `update`                                                                                      |
+| `diun.sort_tags`          | `reverse`                      | [Sort tags method](../faq.md#tags-sorting-when-using-watch_repo) if `diun.watch_repo` enabled. One of `default`, `reverse`, `semver`, `lexicographical` |
+| `diun.max_tags`           | `0`                            | Maximum number of tags to watch if `diun.watch_repo` enabled. `0` means all of them                                                                     |
+| `diun.include_tags`       |                                | Semicolon separated list of regular expressions to include tags. If set, replaces `defaults.includeTags` for this image. Can be useful if you enable `diun.watch_repo` |
+| `diun.exclude_tags`       |                                | Semicolon separated list of regular expressions to exclude tags. If set, replaces `defaults.excludeTags` for this image. Can be useful if you enable `diun.watch_repo` |
+| `diun.hub_link`           | _automatic_                    | Set registry hub link for this image                                                                                                                    |
+| `diun.platform`           | _automatic_                    | Platform to use (e.g. `linux/amd64`)                                                                                                                    |
+| `diun.metadata.*`         | See [below](#default-metadata) | Additional metadata that can be used in [notification template](../faq.md#notification-template) (e.g. `diun.metadata.foo=bar`)                         |
 
 ## Default metadata
 

--- a/docs/providers/nomad.md
+++ b/docs/providers/nomad.md
@@ -217,19 +217,21 @@ Enable watch by default. If false, tasks that don't have `diun.enable = true` in
 
 You can configure more finely the way to analyze the image of your tasks through Nomad meta attributes or service tags:
 
-| Name                | Default                        | Description                                                                                                                                                            |
-|---------------------|--------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `diun.enable`       |                                | Set to true to enable image analysis of this task                                                                                                                      |
-| `diun.regopt`       |                                | [Registry options](../config/regopts.md) name to use                                                                                                                   |
-| `diun.watch_repo`   | `false`                        | Watch all tags of this task image ([be careful](../faq.md#docker-hub-rate-limits) with this setting)                                                                   |
-| `diun.notify_on`    | `new;update`                   | Semicolon separated list of status to be notified: `new`, `update`.                                                                                                    |
-| `diun.sort_tags`    | `reverse`                      | [Sort tags method](../faq.md#tags-sorting-when-using-watch_repo) if `diun.watch_repo` enabled. One of `default`, `reverse`, `semver`, `lexicographical`                |
-| `diun.max_tags`     | `0`                            | Maximum number of tags to watch if `diun.watch_repo` enabled. `0` means all of them                                                                                    |
-| `diun.include_tags` |                                | Semicolon separated list of regular expressions to include tags. If set, replaces `defaults.includeTags` for this image. Can be useful if you enable `diun.watch_repo` |
-| `diun.exclude_tags` |                                | Semicolon separated list of regular expressions to exclude tags. If set, replaces `defaults.excludeTags` for this image. Can be useful if you enable `diun.watch_repo` |
-| `diun.hub_link`     | _automatic_                    | Set registry hub link for this image                                                                                                                                   |
-| `diun.platform`     | _automatic_                    | Platform to use (e.g. `linux/amd64`)                                                                                                                                   |
-| `diun.metadata.*`   | See [below](#default-metadata) | Additional metadata that can be used in [notification template](../faq.md#notification-template) (e.g. `diun.metadata.foo=bar`)                                        |
+| Name                      | Default                        | Description                                                                                                                                             |
+|---------------------------|--------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `diun.enable`             |                                | Set to true to enable image analysis of this container                                                                                                  |
+| `diun.regopt`             |                                | [Registry options](../config/regopts.md) name to use                                                                                                    |
+| `diun.watch_repo`         | `false`                        | Watch all tags of this container image ([be careful](../faq.md#docker-hub-rate-limits) with this setting)                                               |
+| `diun.watch_newer_only`   | `false`                        | Only notify for tags whose semver is strictly greater than the current tag. Non-semver tags (e.g. `latest`) are ignored. Requires `diun.watch_repo`      |
+| `diun.include_prereleases`| `false`                        | When `diun.watch_newer_only` is enabled, also include pre-release tags (e.g. `-rc.1`, `-alpha`). Requires `diun.watch_newer_only`                       |
+| `diun.notify_on`          | `new;update`                   | Semicolon separated list of status to be notified: `new`, `update`                                                                                      |
+| `diun.sort_tags`          | `reverse`                      | [Sort tags method](../faq.md#tags-sorting-when-using-watch_repo) if `diun.watch_repo` enabled. One of `default`, `reverse`, `semver`, `lexicographical` |
+| `diun.max_tags`           | `0`                            | Maximum number of tags to watch if `diun.watch_repo` enabled. `0` means all of them                                                                     |
+| `diun.include_tags`       |                                | Semicolon separated list of regular expressions to include tags. If set, replaces `defaults.includeTags` for this image. Can be useful if you enable `diun.watch_repo` |
+| `diun.exclude_tags`       |                                | Semicolon separated list of regular expressions to exclude tags. If set, replaces `defaults.excludeTags` for this image. Can be useful if you enable `diun.watch_repo` |
+| `diun.hub_link`           | _automatic_                    | Set registry hub link for this image                                                                                                                    |
+| `diun.platform`           | _automatic_                    | Platform to use (e.g. `linux/amd64`)                                                                                                                    |
+| `diun.metadata.*`         | See [below](#default-metadata) | Additional metadata that can be used in [notification template](../faq.md#notification-template) (e.g. `diun.metadata.foo=bar`)                         |
 
 ## Default metadata
 

--- a/docs/providers/swarm.md
+++ b/docs/providers/swarm.md
@@ -176,19 +176,21 @@ Enable watch by default. If false, services that don't have `diun.enable=true` l
 
 You can configure more finely the way to analyze the image of your service through Docker labels:
 
-| Name                | Default                        | Description                                                                                                                                             |
-|---------------------|--------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `diun.enable`       |                                | Set to true to enable image analysis of this service                                                                                                    |
-| `diun.regopt`       |                                | [Registry options](../config/regopts.md) name to use                                                                                                    |
-| `diun.watch_repo`   | `false`                        | Watch all tags of this service image ([be careful](../faq.md#docker-hub-rate-limits) with this setting)                                                 |
-| `diun.notify_on`    | `new;update`                   | Semicolon separated list of status to be notified: `new`, `update`.                                                                                     |
-| `diun.sort_tags`    | `reverse`                      | [Sort tags method](../faq.md#tags-sorting-when-using-watch_repo) if `diun.watch_repo` enabled. One of `default`, `reverse`, `semver`, `lexicographical` |
-| `diun.max_tags`     | `0`                            | Maximum number of tags to watch if `diun.watch_repo` enabled. `0` means all of them                                                                     |
-| `diun.include_tags` |                                | Semicolon separated list of regular expressions to include tags. If set, replaces `defaults.includeTags` for this image. Can be useful if you enable `diun.watch_repo` |
-| `diun.exclude_tags` |                                | Semicolon separated list of regular expressions to exclude tags. If set, replaces `defaults.excludeTags` for this image. Can be useful if you enable `diun.watch_repo` |
-| `diun.hub_link`     | _automatic_                    | Set registry hub link for this image                                                                                                                    |
-| `diun.platform`     | _automatic_                    | Platform to use (e.g. `linux/amd64`)                                                                                                                    |
-| `diun.metadata.*`   | See [below](#default-metadata) | Additional metadata that can be used in [notification template](../faq.md#notification-template) (e.g. `diun.metadata.foo=bar`)                         |
+| Name                      | Default                        | Description                                                                                                                                             |
+|---------------------------|--------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `diun.enable`             |                                | Set to true to enable image analysis of this container                                                                                                  |
+| `diun.regopt`             |                                | [Registry options](../config/regopts.md) name to use                                                                                                    |
+| `diun.watch_repo`         | `false`                        | Watch all tags of this container image ([be careful](../faq.md#docker-hub-rate-limits) with this setting)                                               |
+| `diun.watch_newer_only`   | `false`                        | Only notify for tags whose semver is strictly greater than the current tag. Non-semver tags (e.g. `latest`) are ignored. Requires `diun.watch_repo`      |
+| `diun.include_prereleases`| `false`                        | When `diun.watch_newer_only` is enabled, also include pre-release tags (e.g. `-rc.1`, `-alpha`). Requires `diun.watch_newer_only`                       |
+| `diun.notify_on`          | `new;update`                   | Semicolon separated list of status to be notified: `new`, `update`                                                                                      |
+| `diun.sort_tags`          | `reverse`                      | [Sort tags method](../faq.md#tags-sorting-when-using-watch_repo) if `diun.watch_repo` enabled. One of `default`, `reverse`, `semver`, `lexicographical` |
+| `diun.max_tags`           | `0`                            | Maximum number of tags to watch if `diun.watch_repo` enabled. `0` means all of them                                                                     |
+| `diun.include_tags`       |                                | Semicolon separated list of regular expressions to include tags. If set, replaces `defaults.includeTags` for this image. Can be useful if you enable `diun.watch_repo` |
+| `diun.exclude_tags`       |                                | Semicolon separated list of regular expressions to exclude tags. If set, replaces `defaults.excludeTags` for this image. Can be useful if you enable `diun.watch_repo` |
+| `diun.hub_link`           | _automatic_                    | Set registry hub link for this image                                                                                                                    |
+| `diun.platform`           | _automatic_                    | Platform to use (e.g. `linux/amd64`)                                                                                                                    |
+| `diun.metadata.*`         | See [below](#default-metadata) | Additional metadata that can be used in [notification template](../faq.md#notification-template) (e.g. `diun.metadata.foo=bar`)                         |
 
 ## Default metadata
 

--- a/internal/app/job.go
+++ b/internal/app/job.go
@@ -65,9 +65,11 @@ func (di *Diun) createJob(job model.Job) {
 
 	// Set defaults
 	if err := mergo.Merge(&job.Image, model.Image{
-		Platform:  model.ImagePlatform{},
-		WatchRepo: new(false),
-		MaxTags:   0,
+		Platform:           model.ImagePlatform{},
+		WatchRepo:          new(false),
+		WatchNewerOnly:     new(false),
+		IncludePrereleases: new(false),
+		MaxTags:            0,
 	}); err != nil {
 		sublog.Error().Err(err).Msg("Cannot set default values")
 		return
@@ -125,25 +127,31 @@ func (di *Diun) createJob(job model.Job) {
 		return
 	}
 
-	tags, err := job.Registry.Tags(registry.TagsOptions{
+	tagsOpts := registry.TagsOptions{
 		Image:   job.RegImage,
 		Max:     job.Image.MaxTags,
 		Sort:    job.Image.SortTags,
 		Include: job.Image.IncludeTags,
 		Exclude: job.Image.ExcludeTags,
-	})
+	}
+	if *job.Image.WatchNewerOnly {
+		tagsOpts.MinSemver = prvImage.Tag
+		tagsOpts.IncludePrereleases = *job.Image.IncludePrereleases
+	}
+	tags, err := job.Registry.Tags(tagsOpts)
 	if err != nil {
 		sublog.Error().Err(err).Msg("Cannot list tags from registry")
 		return
 	}
 
-	log.Debug().Str("image", job.RegImage.String()).Msgf("%d tag(s) found in repository. %d will be analyzed (%d max, %d not included, %d excluded, %d artifact tags).",
+	log.Debug().Str("image", job.RegImage.String()).Msgf("%d tag(s) found in repository. %d will be analyzed (%d max, %d not included, %d excluded, %d artifact tags, %d older-or-equal).",
 		tags.Total,
 		len(tags.List),
 		job.Image.MaxTags,
 		tags.NotIncluded,
 		tags.Excluded,
 		tags.Artifacts,
+		tags.OlderOrEqual,
 	)
 
 	for _, tag := range tags.List {

--- a/internal/model/defaults.go
+++ b/internal/model/defaults.go
@@ -6,13 +6,15 @@ import (
 
 // Defaults holds data necessary for image defaults configuration
 type Defaults struct {
-	WatchRepo   *bool             `yaml:"watchRepo,omitempty" json:"watchRepo,omitempty"`
-	NotifyOn    []NotifyOn        `yaml:"notifyOn,omitempty" json:"notifyOn,omitempty"`
-	MaxTags     int               `yaml:"maxTags,omitempty" json:"maxTags,omitempty"`
-	SortTags    registry.SortTag  `yaml:"sortTags,omitempty" json:"sortTags,omitempty"`
-	IncludeTags []string          `yaml:"includeTags,omitempty" json:"includeTags,omitempty"`
-	ExcludeTags []string          `yaml:"excludeTags,omitempty" json:"excludeTags,omitempty"`
-	Metadata    map[string]string `yaml:"metadata,omitempty" json:"metadata,omitempty"`
+	WatchRepo          *bool             `yaml:"watchRepo,omitempty" json:"watchRepo,omitempty"`
+	WatchNewerOnly     *bool             `yaml:"watchNewerOnly,omitempty" json:"watchNewerOnly,omitempty"`
+	IncludePrereleases *bool             `yaml:"includePrereleases,omitempty" json:"includePrereleases,omitempty"`
+	NotifyOn           []NotifyOn        `yaml:"notifyOn,omitempty" json:"notifyOn,omitempty"`
+	MaxTags            int               `yaml:"maxTags,omitempty" json:"maxTags,omitempty"`
+	SortTags           registry.SortTag  `yaml:"sortTags,omitempty" json:"sortTags,omitempty"`
+	IncludeTags        []string          `yaml:"includeTags,omitempty" json:"includeTags,omitempty"`
+	ExcludeTags        []string          `yaml:"excludeTags,omitempty" json:"excludeTags,omitempty"`
+	Metadata           map[string]string `yaml:"metadata,omitempty" json:"metadata,omitempty"`
 }
 
 // GetDefaults gets the default values

--- a/internal/model/image.go
+++ b/internal/model/image.go
@@ -6,18 +6,20 @@ import (
 
 // Image holds image configuration
 type Image struct {
-	Name        string            `yaml:"name,omitempty" json:",omitempty"`
-	Platform    ImagePlatform     `yaml:"platform,omitempty" json:",omitempty"`
-	RegOpt      string            `yaml:"regopt,omitempty" json:",omitempty"`
-	WatchRepo   *bool             `yaml:"watch_repo,omitempty" json:",omitempty"`
-	NotifyOn    []NotifyOn        `yaml:"notify_on,omitempty" json:",omitempty"`
-	MaxTags     int               `yaml:"max_tags,omitempty" json:",omitempty"`
-	SortTags    registry.SortTag  `yaml:"sort_tags,omitempty" json:",omitempty"`
-	IncludeTags []string          `yaml:"include_tags,omitempty" json:",omitempty"`
-	ExcludeTags []string          `yaml:"exclude_tags,omitempty" json:",omitempty"`
-	HubTpl      string            `yaml:"hub_tpl,omitempty" json:",omitempty"`
-	HubLink     string            `yaml:"hub_link,omitempty" json:",omitempty"`
-	Metadata    map[string]string `yaml:"metadata,omitempty" json:",omitempty"`
+	Name               string            `yaml:"name,omitempty" json:",omitempty"`
+	Platform           ImagePlatform     `yaml:"platform,omitempty" json:",omitempty"`
+	RegOpt             string            `yaml:"regopt,omitempty" json:",omitempty"`
+	WatchRepo          *bool             `yaml:"watch_repo,omitempty" json:",omitempty"`
+	WatchNewerOnly     *bool             `yaml:"watch_newer_only,omitempty" json:",omitempty"`
+	IncludePrereleases *bool             `yaml:"include_prereleases,omitempty" json:",omitempty"`
+	NotifyOn           []NotifyOn        `yaml:"notify_on,omitempty" json:",omitempty"`
+	MaxTags            int               `yaml:"max_tags,omitempty" json:",omitempty"`
+	SortTags           registry.SortTag  `yaml:"sort_tags,omitempty" json:",omitempty"`
+	IncludeTags        []string          `yaml:"include_tags,omitempty" json:",omitempty"`
+	ExcludeTags        []string          `yaml:"exclude_tags,omitempty" json:",omitempty"`
+	HubTpl             string            `yaml:"hub_tpl,omitempty" json:",omitempty"`
+	HubLink            string            `yaml:"hub_link,omitempty" json:",omitempty"`
+	Metadata           map[string]string `yaml:"metadata,omitempty" json:",omitempty"`
 }
 
 // ImagePlatform holds image platform configuration

--- a/internal/provider/common.go
+++ b/internal/provider/common.go
@@ -25,6 +25,8 @@ func ValidateImage(image string, metadata, labels map[string]string, watchByDef 
 
 	if defaults != nil {
 		img.WatchRepo = defaults.WatchRepo
+		img.WatchNewerOnly = defaults.WatchNewerOnly
+		img.IncludePrereleases = defaults.IncludePrereleases
 		img.NotifyOn = defaults.NotifyOn
 		img.MaxTags = defaults.MaxTags
 		img.SortTags = defaults.SortTags
@@ -52,6 +54,18 @@ func ValidateImage(image string, metadata, labels map[string]string, watchByDef 
 		case key == "diun.watch_repo":
 			if watchRepo, err := strconv.ParseBool(value); err == nil {
 				img.WatchRepo = new(watchRepo)
+			} else {
+				return img, errors.Wrapf(err, "cannot parse %q value of label %s", value, key)
+			}
+		case key == "diun.watch_newer_only":
+			if v, err := strconv.ParseBool(value); err == nil {
+				img.WatchNewerOnly = new(v)
+			} else {
+				return img, errors.Wrapf(err, "cannot parse %q value of label %s", value, key)
+			}
+		case key == "diun.include_prereleases":
+			if v, err := strconv.ParseBool(value); err == nil {
+				img.IncludePrereleases = new(v)
 			} else {
 				return img, errors.Wrapf(err, "cannot parse %q value of label %s", value, key)
 			}

--- a/pkg/registry/tags.go
+++ b/pkg/registry/tags.go
@@ -13,15 +13,29 @@ import (
 	"golang.org/x/mod/semver"
 )
 
+// normalizeSemver strips non-numeric leading characters and returns a valid
+// semver string (with "v" prefix), or an empty string if the tag cannot be
+// interpreted as semver.
+func normalizeSemver(tag string) string {
+	s := strings.TrimLeftFunc(tag, func(r rune) bool {
+		return !unicode.IsNumber(r)
+	})
+	if vt := fmt.Sprintf("v%s", s); semver.IsValid(vt) {
+		return vt
+	}
+	return ""
+}
+
 var generatedArtifactTagRe = regexp.MustCompile(`^sha256-[a-f0-9]{64}(?:\.(?:att|sbom|sig))?$`)
 
 // Tags holds information about image tags.
 type Tags struct {
-	List        []string
-	NotIncluded int
-	Excluded    int
-	Artifacts   int
-	Total       int
+	List         []string
+	NotIncluded  int
+	Excluded     int
+	Artifacts    int
+	OlderOrEqual int
+	Total        int
 }
 
 // TagsOptions holds docker tags image options
@@ -31,6 +45,12 @@ type TagsOptions struct {
 	Sort    SortTag
 	Include []string
 	Exclude []string
+	// MinSemver, when non-empty, restricts the list to tags whose semver is
+	// strictly greater than this value.  Non-semver tags are silently dropped.
+	MinSemver string
+	// IncludePrereleases controls whether pre-release tags (e.g. -rc.1, -alpha)
+	// are kept when MinSemver filtering is active.
+	IncludePrereleases bool
 }
 
 // Tags returns tags of a Docker repository
@@ -57,6 +77,9 @@ func (c *Client) Tags(opts TagsOptions) (*Tags, error) {
 	// Sort tags
 	tags = SortTags(tags, opts.Sort)
 
+	// Resolve minimum semver once (empty string means no filtering)
+	minSemver := normalizeSemver(opts.MinSemver)
+
 	// Filter
 	for _, tag := range tags {
 		if generatedArtifactTagRe.MatchString(tag) {
@@ -69,6 +92,24 @@ func (c *Client) Tags(opts TagsOptions) (*Tags, error) {
 			res.Excluded++
 			continue
 		}
+
+		if minSemver != "" {
+			tagSemver := normalizeSemver(tag)
+			if tagSemver == "" {
+				// Not a semver tag — skip when newer-only mode is active
+				res.OlderOrEqual++
+				continue
+			}
+			if !opts.IncludePrereleases && semver.Prerelease(tagSemver) != "" {
+				res.OlderOrEqual++
+				continue
+			}
+			if semver.Compare(tagSemver, minSemver) <= 0 {
+				res.OlderOrEqual++
+				continue
+			}
+		}
+
 		res.List = append(res.List, tag)
 	}
 

--- a/pkg/registry/tags_test.go
+++ b/pkg/registry/tags_test.go
@@ -87,6 +87,95 @@ func TestTagsSkipsGeneratedArtifactTags(t *testing.T) {
 	}, tags)
 }
 
+func TestNormalizeSemver(t *testing.T) {
+	cases := []struct {
+		tag      string
+		expected string
+	}{
+		{"1.5.0", "v1.5.0"},
+		{"v1.5.0", "v1.5.0"},
+		{"1.5.0-rc.1", "v1.5.0-rc.1"},
+		{"v2.0.0-alpha", "v2.0.0-alpha"},
+		{"latest", ""},
+		{"edge", ""},
+		{"", ""},
+		{"4", "v4"},
+		{"ubuntu-5.0", "v5.0"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.tag, func(t *testing.T) {
+			assert.Equal(t, tc.expected, normalizeSemver(tc.tag))
+		})
+	}
+}
+
+func TestTagsMinSemver(t *testing.T) {
+	registry := newTestRegistry(t, "acme/myapp")
+	registry.addTagsPage("", []string{
+		"latest",
+		"edge",
+		"1.4.0",
+		"1.5.0",
+		"1.5.1",
+		"1.6.0",
+		"2.0.0",
+		"2.0.0-rc.1",
+		"2.0.0-beta",
+	}, "")
+
+	image, err := ParseImage(ParseImageOptions{
+		Name: registry.imageName("1.5.0"),
+	})
+	require.NoError(t, err)
+	client := newTestRegistryClient(t, Options{})
+
+	t.Run("stable only, no prereleases", func(t *testing.T) {
+		tags, err := client.Tags(TagsOptions{
+			Image:              image,
+			MinSemver:          "1.5.0",
+			IncludePrereleases: false,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"1.5.1", "1.6.0", "2.0.0"}, tags.List)
+		// latest, edge, 1.4.0, 1.5.0, 2.0.0-rc.1, 2.0.0-beta all filtered
+		assert.Equal(t, 6, tags.OlderOrEqual)
+		assert.Equal(t, 9, tags.Total)
+	})
+
+	t.Run("include prereleases", func(t *testing.T) {
+		tags, err := client.Tags(TagsOptions{
+			Image:              image,
+			MinSemver:          "1.5.0",
+			IncludePrereleases: true,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"1.5.1", "1.6.0", "2.0.0", "2.0.0-rc.1", "2.0.0-beta"}, tags.List)
+		assert.Equal(t, 4, tags.OlderOrEqual) // latest, edge, 1.4.0, 1.5.0
+		assert.Equal(t, 9, tags.Total)
+	})
+
+	t.Run("min semver with v prefix", func(t *testing.T) {
+		tags, err := client.Tags(TagsOptions{
+			Image:              image,
+			MinSemver:          "v1.5.0",
+			IncludePrereleases: false,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"1.5.1", "1.6.0", "2.0.0"}, tags.List)
+	})
+
+	t.Run("non-semver min version disables filtering", func(t *testing.T) {
+		tags, err := client.Tags(TagsOptions{
+			Image:     image,
+			MinSemver: "latest",
+		})
+		require.NoError(t, err)
+		// "latest" can't be parsed as semver → no filtering applied
+		assert.Equal(t, 9, len(tags.List))
+		assert.Equal(t, 0, tags.OlderOrEqual)
+	})
+}
+
 func TestTagsSort(t *testing.T) {
 	testCases := []struct {
 		name     string


### PR DESCRIPTION
When you have a fixed version, you have no way of detecting the appearance of a new version.
This option aims to notify you when a new image appears and is more recent, thus limiting notifications.

When watch_repo is enabled, watch_newer_only restricts notifications to tags whose semantic version is strictly greater than the current image tag. Non-semver tags (latest, edge, date-based) are silently ignored. include_prereleases controls whether pre-release tags (-rc.1, -alpha, -beta) that are newer than the current version are included.

Both options are available as labels on all providers (diun.watch_newer_only, diun.include_prereleases), as Defaults config fields (watchNewerOnly, includePrereleases), and in the file provider YAML configuration (watch_newer_only, include_prereleases).


Note: I received help from Claude Sonnet 4.6 for the pull request. And this is my first pull request on this repository, so any feedback is welcome :)