### PR TITLE
Add LOG_TIMESTAMP option to allow disabling printing of timestamps in log output

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -25,6 +25,7 @@ type ServeCmd struct {
 	LogJSON       bool   `name:"log-json" env:"LOG_JSON" default:"false" help:"Enable JSON logging output.'"`
 	LogCaller     bool   `name:"log-caller" env:"LOG_CALLER" default:"false" help:"Add file:line of the caller to log output."`
 	LogNoColor    bool   `name:"log-nocolor" env:"LOG_NOCOLOR" default:"false" help:"Disables the colorized output."`
+	LogTimestamp  bool   `name:"log-timestamp" env:"LOG_TIMESTAMP" default:"true" help:"Logs the timestamp in log output"`
 	GRPCAuthority string `name:"grpc-authority" env:"GRPC_AUTHORITY" default:":42286" help:"Address used to expose the gRPC server."`
 }
 
@@ -33,10 +34,11 @@ func (s *ServeCmd) Run(ctx *Context) error {
 	defer stop()
 
 	logging.Configure(logging.Options{
-		LogLevel:   s.LogLevel,
-		LogJSON:    s.LogJSON,
-		LogCaller:  s.LogCaller,
-		LogNoColor: s.LogNoColor,
+		LogLevel:     s.LogLevel,
+		LogJSON:      s.LogJSON,
+		LogCaller:    s.LogCaller,
+		LogNoColor:   s.LogNoColor,
+		LogTimestamp: s.LogTimestamp,
 	})
 	log.Info().Str("version", version).Msgf("Starting %s", ctx.Meta.Name)
 

--- a/docs/usage/command-line.md
+++ b/docs/usage/command-line.md
@@ -45,6 +45,7 @@ Following environment variables can also be used in place:
 | `LOG_JSON`       | `false`  | Enable JSON logging output                                           |
 | `LOG_CALLER`     | `false`  | Enable to add `file:line` of the caller                              |
 | `LOG_NOCOLOR`    | `false`  | Disables the colorized output                                        |
+| `LOG_TIMESTAMP`  | `true`   | Enables timestamps in log output                                     |
 | `GRPC_AUTHORITY` | `:42286` | Address used to expose the gRPC server                               |
 
 ### `healthcheck`

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -12,10 +12,11 @@ import (
 )
 
 type Options struct {
-	LogLevel   string
-	LogJSON    bool
-	LogCaller  bool
-	LogNoColor bool
+	LogLevel     string
+	LogJSON      bool
+	LogCaller    bool
+	LogNoColor   bool
+	LogTimestamp bool
 }
 
 // Configure configures logger
@@ -36,7 +37,12 @@ func Configure(opts Options) {
 		w = os.Stdout
 	}
 
-	ctx := zerolog.New(w).With().Timestamp()
+	var ctx zerolog.Context
+	if opts.LogTimestamp {
+		ctx = zerolog.New(w).With().Timestamp()
+	} else {
+		ctx = zerolog.New(w).With()
+	}
 	if opts.LogCaller {
 		ctx = ctx.Caller()
 	}


### PR DESCRIPTION
For use when going directly to journald/syslog. Default `true`.

Output (note the `<nil>` is reported in https://github.com/rs/zerolog/issues/725):
```bash
root@localhost:~/diun# docker run --rm -it -e LOG_JSON=false -e LOG_TIMESTAMP=false docker.io/library/diun:local
<nil> INF Starting Diun version=v4.33.0-8-g14095852.m
<nil> INF Configuration loaded from 1 environment variable(s)
<nil> FTL error="cannot load configuration: at least one provider is required"
root@localhost:~/diun# docker run --rm -it -e LOG_JSON=false  docker.io/library/diun:local
Mon, 22 Jun 2026 18:01:50 UTC INF Starting Diun version=v4.33.0-8-g14095852.m
Mon, 22 Jun 2026 18:01:50 UTC INF Configuration loaded from 1 environment variable(s)
Mon, 22 Jun 2026 18:01:50 UTC FTL error="cannot load configuration: at least one provider is required"
```

JSON output:

```json
root@localhost:~/diun# docker run --rm -it -e LOG_JSON=true  docker.io/library/diun:local
{"level":"info","version":"v4.33.0-8-g14095852.m","time":"2026-06-22T18:02:45Z","message":"Starting Diun"}
{"level":"info","time":"2026-06-22T18:02:45Z","message":"Configuration loaded from 1 environment variable(s)"}
{"level":"fatal","error":"cannot load configuration: at least one provider is required","time":"2026-06-22T18:02:45Z"}
root@localhost:~/diun# docker run --rm -it -e LOG_JSON=true -e LOG_TIMESTAMP=false docker.io/library/diun:local
{"level":"info","version":"v4.33.0-8-g14095852.m","message":"Starting Diun"}
{"level":"info","message":"Configuration loaded from 1 environment variable(s)"}
{"level":"fatal","error":"cannot load configuration: at least one provider is required"}
```

# Problem statement

I'm running in podman (quadlet) with LogDriver=journald and the timestamp duplicates the journal's and takes up space, making the logs harder to read:

```
Jun 08 10:37:41 allecto diun[499927]: {"level":"info","version":"v4.33.0","time":"2026-06-08T10:37:41-04:00","message":>
Jun 08 10:37:41 allecto diun[499927]: {"level":"info","time":"2026-06-08T10:37:41-04:00","message":"Configuration loade>
```

Note how the ending with a `>` - that's journald's default "line continues to the right" and is sized to my window size.